### PR TITLE
ACS-6550 Use final product name 'Alfresco Connector for Hyland Experience Insight'.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Alfresco HxInsight Connector CI
+name: Alfresco Connector for Hyland Experience Insight CI
 
 on:
   pull_request:
@@ -155,14 +155,14 @@ jobs:
       - name: "Make release and deploy to Nexus"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: mvn ${{ env.MAVEN_CLI_OPTS }} -DreleaseVersion="${{ env.RELEASE_VERSION }}" -DdevelopmentVersion="${{ env.DEVELOPMENT_VERSION }}" -Dtag="${{ env.RELEASE_VERSION }}" -Dusername="${{ secrets.BOT_GITHUB_USERNAME }}" -Dpassword="${{ secrets.BOT_GITHUB_TOKEN }}" -DscmCommentPrefix="[maven-release-plugin][skip ci]" -DskipTests -Dproject.revision.key=${{ github.sha }} "-Darguments=-DskipTests -Dadditionalparam=-Xdoclint:none -Dproject.revision.key=${{ github.sha }}" release:prepare release:perform
-      - run: mkdir -p deploy_dir/community/hxi-connector/${{ env.RELEASE_VERSION }}
+      - run: mkdir -p deploy_dir/community/hxinsight-connector/${{ env.RELEASE_VERSION }}
       - name: "Move the final artifacts to a single folder (deploy_dir) to be copied to S3"
-        run: mv "distribution/target/alfresco-hxinsight-connector-distribution-${{ env.RELEASE_VERSION }}.zip" "deploy_dir/community/hxi-connector/${{ env.RELEASE_VERSION }}/"
+        run: mv "distribution/target/alfresco-hxinsight-connector-distribution-${{ env.RELEASE_VERSION }}.zip" "deploy_dir/community/hxinsight-connector/${{ env.RELEASE_VERSION }}/"
       - name: "Clone Alfresco/third-party-license-overrides"
         run: git clone --depth=1 https://github.com/Alfresco/third-party-license-overrides.git
       - uses: actions/setup-python@v3
       - name: "Create third party license csv file and add it to the deploy directory"
-        run: python3 ./third-party-license-overrides/thirdPartyLicenseCSVCreator.py --project "${{ github.workspace }}" --version "${{ env.RELEASE_VERSION }}" --combined --output "deploy_dir/community/hxi-connector/${{ env.RELEASE_VERSION }}"
+        run: python3 ./third-party-license-overrides/thirdPartyLicenseCSVCreator.py --project "${{ github.workspace }}" --version "${{ env.RELEASE_VERSION }}" --combined --output "deploy_dir/community/hxinsight-connector/${{ env.RELEASE_VERSION }}"
       - name: "Configure AWS credentials"
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -235,5 +235,5 @@ jobs:
       - name: "Check release version and copy to S3 Downloads Bucket"
         run: |
           if [[ ${{ env.RELEASE_VERSION }} =~ ^[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
-              aws s3 cp --recursive --acl private --copy-props none "s3://alfresco-artefacts-staging/community/hxi-connector/${{ env.RELEASE_VERSION }}/" "s3://eu.dl.alfresco.com/release/community/hxi-connector/${{ env.RELEASE_VERSION }}/"
+              aws s3 cp --recursive --acl private --copy-props none "s3://alfresco-artefacts-staging/community/hxinsight-connector/${{ env.RELEASE_VERSION }}/" "s3://eu.dl.alfresco.com/release/community/hxinsight-connector/${{ env.RELEASE_VERSION }}/"
           fi

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Alfresco HxInsight Connector
+# Alfresco Connector for Hyland Experience Insight
 
-Connector for sending ACS events to HxInsight and updating the Repository with the predictions that it generates.
+Connector for sending ACS events to Hx Insight and updating the Repository with the predictions that it generates.
 
 
 ### Code Quality

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -1,6 +1,6 @@
-# Alfresco HxInsight Connector
+# Alfresco Connector for Hyland Experience Insight
 
-Full project details and source code is available at https://github.com/Alfresco/hxi-connector
+Full project details and source code is available at https://github.com/Alfresco/hxinsight-connector
 
 ## Licenses
 

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -6,7 +6,7 @@
         <version>0.0.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <name>Alfresco HxInsight Connector :: Distribution zip</name>
+    <name>Alfresco Connector for Hyland Experience Insight :: Distribution zip</name>
     <artifactId>alfresco-hxinsight-connector-distribution</artifactId>
     <packaging>jar</packaging>
 

--- a/distribution/src/main/resources/docker-compose-origin/.env
+++ b/distribution/src/main/resources/docker-compose-origin/.env
@@ -11,4 +11,4 @@ ACS_NGINX_TAG=@dist.nginx.version@
 ELASTICSEARCH_TAG=@dist.elasticsearch.version@
 SEARCH_ENTERPRISE_TAG=@dist.search.enterprise.version@
 LOCALSTACK_TAG=@dist.localstack.version@
-HXI_CONNECTOR_TAG=@project.version@
+HXINSIGHT_CONNECTOR_TAG=@project.version@

--- a/distribution/src/main/resources/docker-compose/docker-compose.yml
+++ b/distribution/src/main/resources/docker-compose/docker-compose.yml
@@ -190,7 +190,7 @@ services:
       ALFRESCO_ACCEPTEDCONTENTMEDIATYPESCACHE_BASEURL: http://transform-core-aio:8090/transform/config
 
   live-ingester:
-    image: quay.io/alfresco/alfresco-hxinsight-connector-live-ingester:${HXI_CONNECTOR_TAG}
+    image: quay.io/alfresco/alfresco-hxinsight-connector-live-ingester:${HXINSIGHT_CONNECTOR_TAG}
     depends_on:
       - activemq
     environment:

--- a/live-ingester/pom.xml
+++ b/live-ingester/pom.xml
@@ -10,7 +10,7 @@
 
 	<packaging>jar</packaging>
 	<artifactId>alfresco-hxinsight-connector-live-ingester</artifactId>
-	<name>Alfresco HxInsight Connector :: Live Ingester</name>
+	<name>Alfresco Connector for Hyland Experience Insight :: Live Ingester</name>
 	<version>0.0.3-SNAPSHOT</version>
 
 	<dependencies>

--- a/live-ingester/src/main/resources/application.yml
+++ b/live-ingester/src/main/resources/application.yml
@@ -19,4 +19,4 @@ alfresco:
       request:
         endpoint: activemq:queue:acs-repo-transform-request?jmsMessageType=Text
         timeout: 20000
-      response.queueName: org.alfresco.hxi-connector.transform.response
+      response.queueName: org.alfresco.hxinsight-connector.transform.response

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>alfresco-hxinsight-connector-parent</artifactId>
   <packaging>pom</packaging>
-  <name>Alfresco HxInsight Connector :: Parent</name>
+  <name>Alfresco Connector for Hyland Experience Insight :: Parent</name>
   <version>0.0.3-SNAPSHOT</version>
 
   <modules>
@@ -45,7 +45,7 @@
   <properties>
     <maven.build.sourceVersion>17</maven.build.sourceVersion>
     <project.scm.organization>Alfresco</project.scm.organization>
-    <project.scm.repository>hxi-connector</project.scm.repository>
+    <project.scm.repository>hxinsight-connector</project.scm.repository>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.year>2023</project.year>


### PR DESCRIPTION
I have left the references in packages as "hxi", but changed the customer-facing locations to either the full name or "Hx Insight." In particular this will affect the git repository (which will need renaming to "hxinsight-connector") and the S3 release bucket (which will also be updated to "hxinsight-connector").