### PR TITLE
ACS-6379: Fix app start-up Camel error

### DIFF
--- a/live-ingester/pom.xml
+++ b/live-ingester/pom.xml
@@ -51,8 +51,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-mock</artifactId>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-mock-starter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Fix app start-up Camel error `NoClassDefFoundError: org/apache/camel/component/mock/MockComponent`

For more see: https://alfresco.atlassian.net/browse/ACS-6379