### PR TITLE
ACS-6376 Include objectId in HxInsight call.

### DIFF
--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/config/jackson/UpdateNodeMetadataEventSerializer.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/config/jackson/UpdateNodeMetadataEventSerializer.java
@@ -27,6 +27,7 @@
 package org.alfresco.hxi_connector.live_ingester.adapters.config.jackson;
 
 import java.io.IOException;
+import java.util.Set;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
@@ -58,13 +59,19 @@ public class UpdateNodeMetadataEventSerializer extends StdSerializer<UpdateNodeM
         {
             jgen.writeStartObject();
 
-            jgen.writeArrayFieldStart("setProperties");
+            jgen.writeStringField("objectId", event.getObjectId());
+
+            jgen.writeArrayFieldStart("properties");
             event.getMetadataPropertiesToSet().values().forEach(property -> writeProperty(jgen, property));
             jgen.writeEndArray();
 
-            jgen.writeArrayFieldStart("unsetProperties");
-            event.getMetadataPropertiesToUnset().forEach(propertyName -> writePropertyName(jgen, propertyName));
-            jgen.writeEndArray();
+            Set<String> metadataPropertiesToUnset = event.getMetadataPropertiesToUnset();
+            if (!metadataPropertiesToUnset.isEmpty())
+            {
+                jgen.writeArrayFieldStart("removedProperties");
+                metadataPropertiesToUnset.forEach(propertyName -> writePropertyName(jgen, propertyName));
+                jgen.writeEndArray();
+            }
 
             jgen.writeEndObject();
         }

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/domain/ports/ingestion_engine/UpdateNodeMetadataEvent.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/domain/ports/ingestion_engine/UpdateNodeMetadataEvent.java
@@ -32,15 +32,18 @@ import java.util.Map;
 import java.util.Set;
 
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor(staticName = "create")
 public class UpdateNodeMetadataEvent
 {
+    private final String objectId;
     private final Map<String, NodeProperty<?>> metadataPropertiesToSet = new HashMap<>();
-
     private final Set<String> metadataPropertiesToUnset = new HashSet<>();
+
+    public UpdateNodeMetadataEvent(String objectId)
+    {
+        this.objectId = objectId;
+    }
 
     public UpdateNodeMetadataEvent set(NodeProperty<?> metadataProperty)
     {

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/metadata/IngestMetadataCommandHandler.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/metadata/IngestMetadataCommandHandler.java
@@ -56,7 +56,7 @@ public class IngestMetadataCommandHandler
 
     public void handle(IngestMetadataCommand command)
     {
-        UpdateNodeMetadataEvent updateMetadataEvent = UpdateNodeMetadataEvent.create();
+        UpdateNodeMetadataEvent updateMetadataEvent = new UpdateNodeMetadataEvent(command.nodeId());
 
         command.name().applyAs(NAME, updateMetadataEvent);
         command.primaryAssocQName().applyAs(PRIMARY_ASSOC_Q_NAME, updateMetadataEvent);

--- a/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/config/jackson/UpdateNodeMetadataEventSerializerTest.java
+++ b/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/config/jackson/UpdateNodeMetadataEventSerializerTest.java
@@ -26,7 +26,7 @@
 
 package org.alfresco.hxi_connector.live_ingester.adapters.config.jackson;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import static org.alfresco.hxi_connector.live_ingester.domain.usecase.metadata.model.PredefinedNodeMetadataProperty.CREATED_BY_USER_WITH_ID;
 import static org.alfresco.hxi_connector.live_ingester.domain.usecase.metadata.model.PredefinedNodeMetadataProperty.IS_FILE;

--- a/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/domain/ports/ingestion_engine/UpdateNodeMetadataEventTest.java
+++ b/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/domain/ports/ingestion_engine/UpdateNodeMetadataEventTest.java
@@ -37,12 +37,13 @@ import org.junit.jupiter.api.Test;
 
 class UpdateNodeMetadataEventTest
 {
+    private static final String NODE_ID = "node-id";
 
     @Test
     void shouldOverwriteAlreadySetProperty()
     {
         // given
-        UpdateNodeMetadataEvent updateNodeMetadataEvent = UpdateNodeMetadataEvent.create();
+        UpdateNodeMetadataEvent updateNodeMetadataEvent = new UpdateNodeMetadataEvent(NODE_ID);
 
         NodeProperty<String> name1 = NAME.withValue("name-1");
         NodeProperty<String> name2 = NAME.withValue("name-2");
@@ -60,7 +61,7 @@ class UpdateNodeMetadataEventTest
     void shouldNotDuplicatePropertiesToUnset()
     {
         // given
-        UpdateNodeMetadataEvent updateNodeMetadataEvent = UpdateNodeMetadataEvent.create();
+        UpdateNodeMetadataEvent updateNodeMetadataEvent = new UpdateNodeMetadataEvent(NODE_ID);
 
         // when
         updateNodeMetadataEvent.unset(CREATED_BY_USER_WITH_ID.getName());


### PR DESCRIPTION
Also fix names of other fields and make UpdateNodeMetadataEventSerializerTest less brittle.