### PR TITLE
ACS-6380: [HxI LI] Added Camel-retry logic to PreSignedUrlRequester

### DIFF
--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/config/IntegrationConfig.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/config/IntegrationConfig.java
@@ -1,0 +1,23 @@
+package org.alfresco.hxi_connector.live_ingester.adapters.config;
+
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(IntegrationConfig.Properties.class)
+public class IntegrationConfig
+{
+
+    @ConfigurationProperties(prefix = "alfresco.integration")
+    public record Properties(Storage storage)
+    {}
+
+    public record Storage(String endpoint, Retry retry)
+    {}
+
+    public record Retry(int attempts, int initialDelay, double delayMultiplier, List<Class<? extends Throwable>> reasons)
+    {}
+}

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/config/IntegrationConfig.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/config/IntegrationConfig.java
@@ -1,3 +1,28 @@
+/*
+ * #%L
+ * Alfresco HX Insight Connector
+ * %%
+ * Copyright (C) 2024 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
 package org.alfresco.hxi_connector.live_ingester.adapters.config;
 
 import java.util.List;

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/storage/connector/PreSignedUrlRequester.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/storage/connector/PreSignedUrlRequester.java
@@ -29,64 +29,81 @@ import static org.apache.camel.Exchange.HTTP_RESPONSE_CODE;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.List;
 import java.util.Map;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.LoggingLevel;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.dataformat.JsonLibrary;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import org.alfresco.hxi_connector.live_ingester.domain.exception.LiveIngesterRuntimeException;
+import org.alfresco.hxi_connector.live_ingester.adapters.config.IntegrationConfig;
+import org.alfresco.hxi_connector.live_ingester.domain.exception.EndpointClientErrorException;
+import org.alfresco.hxi_connector.live_ingester.domain.exception.EndpointServerErrorException;
 
 @Component
+@RequiredArgsConstructor
 @Slf4j
 public class PreSignedUrlRequester extends RouteBuilder implements StorageLocationRequester
 {
     private static final String LOCAL_ENDPOINT = "direct:" + PreSignedUrlRequester.class.getSimpleName();
+    private static final String LOCAL_RETRYABLE_ENDPOINT = "direct:retryable-" + PreSignedUrlRequester.class.getSimpleName();
     static final String ROUTE_ID = PreSignedUrlRequester.class.getSimpleName();
+    private static final String UNEXPECTED_STATUS_CODE_MESSAGE = "Unexpected response status code - expecting: %d, received: %d";
+    private static final int EXPECTED_STATUS_CODE = 201;
     static final String STORAGE_LOCATION_PROPERTY = "preSignedUrl";
     static final String NODE_ID_PROPERTY = "objectId";
     static final String CONTENT_TYPE_PROPERTY = "contentType";
-    private static final int EXPECTED_STATUS_CODE = 201;
 
     private final CamelContext camelContext;
-
-    private final String targetEndpoint;
-
-    @Autowired
-    public PreSignedUrlRequester(CamelContext camelContext, @Value("${alfresco.integration.storage.endpoint}") String targetEndpoint)
-    {
-        super(camelContext);
-        this.camelContext = camelContext;
-        this.targetEndpoint = targetEndpoint;
-    }
+    private final IntegrationConfig.Properties integrationProperties;
 
     @Override
+    @SuppressWarnings("unchecked")
     public void configure()
     {
-        onException(Exception.class)
-                .log(LoggingLevel.ERROR, log, "Unexpected response. Body: ${body}")
+        List<Class<? extends Throwable>> retryReasons = integrationProperties.storage().retry().reasons();
+        // @formatter:off
+        if (retryReasons != null && !retryReasons.isEmpty())
+        {
+            onException(retryReasons.toArray(Class[]::new))
+                .retryAttemptedLogLevel(LoggingLevel.WARN)
+                .logExhaustedMessageBody(true)
+                .log(LoggingLevel.ERROR, log, "Unexpected response. Headers: ${headers}, Body: ${body}")
+                .maximumRedeliveries(integrationProperties.storage().retry().attempts())
+                .redeliveryDelay(integrationProperties.storage().retry().initialDelay())
+                .backOffMultiplier(integrationProperties.storage().retry().delayMultiplier())
                 .stop();
+        }
+
+        onException(Exception.class)
+            .log(LoggingLevel.ERROR, log, "Unexpected response. Headers: ${headers}, Body: ${body}")
+            .stop();
 
         from(LOCAL_ENDPOINT)
-                .id(ROUTE_ID)
-                .marshal()
-                .json()
-                .to(targetEndpoint)
-                .choice()
-                .when(header(HTTP_RESPONSE_CODE).isEqualTo(String.valueOf(EXPECTED_STATUS_CODE)))
+            .id(ROUTE_ID)
+            .marshal()
+            .json()
+            .to(LOCAL_RETRYABLE_ENDPOINT)
+            .end();
+
+        from(LOCAL_RETRYABLE_ENDPOINT)
+            .errorHandler(noErrorHandler())
+            .to(integrationProperties.storage().endpoint())
+            .choice()
+            .when(header(HTTP_RESPONSE_CODE).isEqualTo(String.valueOf(EXPECTED_STATUS_CODE)))
                 .unmarshal()
                 .json(JsonLibrary.Jackson, Map.class)
                 .process(PreSignedUrlRequester::extractUrl)
-                .otherwise()
+            .otherwise()
                 .process(PreSignedUrlRequester::throwUnexpectedStatusCodeException)
-                .endChoice()
-                .end();
+            .endChoice()
+            .end();
+        // @formatter:on
     }
 
     @Override
@@ -114,18 +131,30 @@ public class PreSignedUrlRequester extends RouteBuilder implements StorageLocati
             }
             catch (MalformedURLException e)
             {
-                throw new LiveIngesterRuntimeException("Parsing URL from response property failed!", e);
+                throw new EndpointServerErrorException("Parsing URL from response property failed!", e);
             }
         }
         else
         {
-            throw new LiveIngesterRuntimeException("Missing " + STORAGE_LOCATION_PROPERTY + " property in response!");
+            throw new EndpointServerErrorException("Missing " + STORAGE_LOCATION_PROPERTY + " property in response!");
         }
     }
 
     @SuppressWarnings("PMD.UnusedPrivateMethod")
     private static void throwUnexpectedStatusCodeException(Exchange exchange)
     {
-        throw new LiveIngesterRuntimeException("Unexpected response status code - expecting: " + EXPECTED_STATUS_CODE + ", received: " + exchange.getMessage().getHeader(HTTP_RESPONSE_CODE, Integer.class));
+        int actualStatusCode = exchange.getMessage().getHeader(HTTP_RESPONSE_CODE, Integer.class);
+        if (actualStatusCode >= 400 && actualStatusCode <= 499)
+        {
+            throw new EndpointClientErrorException(UNEXPECTED_STATUS_CODE_MESSAGE.formatted(EXPECTED_STATUS_CODE, actualStatusCode));
+        }
+        else if (actualStatusCode >= 500 && actualStatusCode <= 599)
+        {
+            throw new EndpointServerErrorException(UNEXPECTED_STATUS_CODE_MESSAGE.formatted(EXPECTED_STATUS_CODE, actualStatusCode));
+        }
+        else if (actualStatusCode != EXPECTED_STATUS_CODE)
+        {
+            log.warn(UNEXPECTED_STATUS_CODE_MESSAGE.formatted(EXPECTED_STATUS_CODE, actualStatusCode));
+        }
     }
 }

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/domain/exception/EndpointClientErrorException.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/domain/exception/EndpointClientErrorException.java
@@ -1,0 +1,39 @@
+/*
+ * #%L
+ * Alfresco HX Insight Connector
+ * %%
+ * Copyright (C) 2024 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.hxi_connector.live_ingester.domain.exception;
+
+public class EndpointClientErrorException extends RuntimeException
+{
+    public EndpointClientErrorException(String message)
+    {
+        super(message);
+    }
+
+    public EndpointClientErrorException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/domain/exception/EndpointServerErrorException.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/domain/exception/EndpointServerErrorException.java
@@ -1,0 +1,39 @@
+/*
+ * #%L
+ * Alfresco HX Insight Connector
+ * %%
+ * Copyright (C) 2024 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.hxi_connector.live_ingester.domain.exception;
+
+public class EndpointServerErrorException extends RuntimeException
+{
+    public EndpointServerErrorException(String message)
+    {
+        super(message);
+    }
+
+    public EndpointServerErrorException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/live-ingester/src/main/resources/application.yml
+++ b/live-ingester/src/main/resources/application.yml
@@ -22,6 +22,19 @@ alfresco:
         &authPassword=${hyland.experience.insight.api.password}\
         &authenticationPreemptive=true\
         &throwExceptionOnFailure=false"
+      retry:
+        attempts: 10
+        initialDelay: 1000
+        deleyMultiplier: 2
+        reasons:
+          - org.alfresco.hxi_connector.live_ingester.domain.exception.EndpointServerErrorException
+          - java.net.UnknownHostException
+          - java.net.MalformedURLException
+          - com.fasterxml.jackson.core.io.JsonEOFException
+          - com.fasterxml.jackson.databind.exc.MismatchedInputException
+          - org.apache.hc.client5.http.HttpHostConnectException
+          - org.apache.hc.core5.http.MalformedChunkCodingException
+          - org.apache.hc.core5.http.NoHttpResponseException
   ingester:
     messaging:
       in.endpoint: activemq:topic:alfresco.repo.event2

--- a/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/storage/connector/PreSignedUrlRequesterIntegrationTest.java
+++ b/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/storage/connector/PreSignedUrlRequesterIntegrationTest.java
@@ -49,10 +49,12 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 import org.wiremock.integrations.testcontainers.WireMockContainer;
 
+import org.alfresco.hxi_connector.live_ingester.adapters.config.IntegrationConfig;
 import org.alfresco.hxi_connector.live_ingester.util.DockerTags;
 
 @SpringBootTest(classes = {
         CamelAutoConfiguration.class,
+        IntegrationConfig.class,
         PreSignedUrlRequester.class})
 @ActiveProfiles({"test"})
 @Testcontainers

--- a/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/storage/connector/PreSignedUrlRequesterTest.java
+++ b/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/storage/connector/PreSignedUrlRequesterTest.java
@@ -37,32 +37,44 @@ import static org.alfresco.hxi_connector.live_ingester.adapters.storage.connecto
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.UnknownHostException;
+import java.util.List;
 import java.util.stream.Stream;
 
 import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.io.JsonEOFException;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import lombok.SneakyThrows;
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.model.language.ConstantExpression;
+import org.apache.hc.client5.http.HttpHostConnectException;
+import org.apache.hc.core5.http.MalformedChunkCodingException;
+import org.apache.hc.core5.http.NoHttpResponseException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
-import org.alfresco.hxi_connector.live_ingester.domain.exception.LiveIngesterRuntimeException;
+import org.alfresco.hxi_connector.live_ingester.adapters.config.IntegrationConfig;
+import org.alfresco.hxi_connector.live_ingester.domain.exception.EndpointClientErrorException;
+import org.alfresco.hxi_connector.live_ingester.domain.exception.EndpointServerErrorException;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class PreSignedUrlRequesterTest
 {
     private static final String MOCK_ENDPOINT = "mock:hxi-endpoint";
     private static final int STATUS_CODE_201 = 201;
-    private static final int STATUS_CODE_500 = 500;
+    private static final int RETRY_ATTEMPTS_COUNT = 5;
     private static final String NODE_REF = "node-ref";
     private static final String CONTENT_TYPE = "content/type";
     private static final String STORAGE_LOCATION = "http://dummy-url";
     private static final String RESPONSE_BODY_PATTERN = "{\"%s\": \"%s\"}";
     private static final String RESPONSE_BODY = createResponseBodyWith(STORAGE_LOCATION_PROPERTY, STORAGE_LOCATION);
+    private static final List<Class<? extends Throwable>> retryReasons = List.of(EndpointServerErrorException.class, UnknownHostException.class, MalformedURLException.class,
+            JsonEOFException.class, MismatchedInputException.class, HttpHostConnectException.class, NoHttpResponseException.class, MalformedChunkCodingException.class);
 
     CamelContext camelContext;
     MockEndpoint mockEndpoint;
@@ -74,11 +86,18 @@ class PreSignedUrlRequesterTest
     void beforeAll()
     {
         camelContext = new DefaultCamelContext();
-        preSignedUrlRequester = new PreSignedUrlRequester(camelContext, MOCK_ENDPOINT);
+        IntegrationConfig.Properties integrationProperties = integrationPropertiesOf(MOCK_ENDPOINT, RETRY_ATTEMPTS_COUNT);
+        preSignedUrlRequester = new PreSignedUrlRequester(camelContext, integrationProperties);
         camelContext.addRoutes(preSignedUrlRequester);
         camelContext.start();
 
         mockEndpoint = camelContext.getEndpoint(MOCK_ENDPOINT, MockEndpoint.class);
+    }
+
+    @BeforeEach
+    void setUp()
+    {
+        mockEndpoint.reset();
     }
 
     @AfterAll
@@ -94,6 +113,7 @@ class PreSignedUrlRequesterTest
         StorageLocationRequest request = createStorageLocationRequestMock();
         mockEndpointWillRespondWith(STATUS_CODE_201, RESPONSE_BODY);
         mockEndpointWillExpectInRequestBody(NODE_ID_PROPERTY, NODE_REF, CONTENT_TYPE_PROPERTY, CONTENT_TYPE);
+        mockEndpoint.expectedMessageCount(1);
 
         // when
         URL url = preSignedUrlRequester.requestStorageLocation(request);
@@ -104,77 +124,138 @@ class PreSignedUrlRequesterTest
     }
 
     @Test
-    void testRequestStorageLocation_invalidResponseStatusCode()
+    void testRequestStorageLocation_serverError_doRetry() throws InterruptedException
     {
         // given
         StorageLocationRequest request = createStorageLocationRequestMock();
-        mockEndpointWillRespondWith(STATUS_CODE_500);
+        mockEndpointWillRespondWith(500, "Error message");
+        mockEndpoint.expectedMessageCount(RETRY_ATTEMPTS_COUNT + 1);
 
         // when
         Throwable thrown = catchThrowable(() -> preSignedUrlRequester.requestStorageLocation(request));
 
         // then
+        mockEndpoint.assertIsSatisfied();
         assertThat(thrown)
-                .cause()
-                .isInstanceOf(LiveIngesterRuntimeException.class)
-                .hasMessageContaining("received:", STATUS_CODE_500);
+                .cause().isInstanceOf(EndpointServerErrorException.class)
+                .hasMessageContaining("received:", 500);
     }
 
     @Test
-    void testRequestStorageLocation_missingStorageLocationPropertyInResponse()
+    void testRequestStorageLocation_clientError_dontRetry() throws InterruptedException
+    {
+        // given
+        StorageLocationRequest request = createStorageLocationRequestMock();
+        mockEndpointWillRespondWith(400);
+        mockEndpoint.expectedMessageCount(1);
+
+        // when
+        Throwable thrown = catchThrowable(() -> preSignedUrlRequester.requestStorageLocation(request));
+
+        // then
+        mockEndpoint.assertIsSatisfied();
+        assertThat(thrown)
+                .cause().isInstanceOf(EndpointClientErrorException.class)
+                .hasMessageContaining("received:", 400);
+    }
+
+    @Test
+    void testRequestStorageLocation_emptyResponseBody_doRetry() throws InterruptedException
+    {
+        // given
+        StorageLocationRequest request = createStorageLocationRequestMock();
+        mockEndpointWillRespondWith(STATUS_CODE_201, "");
+        mockEndpoint.expectedMessageCount(RETRY_ATTEMPTS_COUNT + 1);
+
+        // when
+        Throwable thrown = catchThrowable(() -> preSignedUrlRequester.requestStorageLocation(request));
+
+        // then
+        mockEndpoint.assertIsSatisfied();
+        assertThat(thrown)
+                .cause().isInstanceOf(MismatchedInputException.class)
+                .message().isNotEmpty();
+    }
+
+    @Test
+    void testRequestStorageLocation_missingPropertyInResponse_doRetry() throws InterruptedException
     {
         // given
         StorageLocationRequest request = createStorageLocationRequestMock();
         String responseBodyWithoutUrl = createResponseBodyWith("unexpectedProperty", STORAGE_LOCATION);
         mockEndpointWillRespondWith(STATUS_CODE_201, responseBodyWithoutUrl);
+        mockEndpoint.expectedMessageCount(RETRY_ATTEMPTS_COUNT + 1);
 
         // when
         Throwable thrown = catchThrowable(() -> preSignedUrlRequester.requestStorageLocation(request));
 
         // then
+        mockEndpoint.assertIsSatisfied();
         assertThat(thrown)
-                .cause()
-                .isInstanceOf(LiveIngesterRuntimeException.class)
+                .cause().isInstanceOf(EndpointServerErrorException.class)
                 .hasMessageContaining("Missing", STORAGE_LOCATION_PROPERTY);
     }
 
     @Test
-    void testRequestStorageLocation_invalidJsonResponse()
+    void testRequestStorageLocation_malformedJsonInResponse_doRetry() throws InterruptedException
     {
         // given
         StorageLocationRequest request = createStorageLocationRequestMock();
         String invalidJsonBody = removeLastCharacter(RESPONSE_BODY);
         mockEndpointWillRespondWith(STATUS_CODE_201, invalidJsonBody);
+        mockEndpoint.expectedMessageCount(RETRY_ATTEMPTS_COUNT + 1);
 
         // when
         Throwable thrown = catchThrowable(() -> preSignedUrlRequester.requestStorageLocation(request));
 
         // then
+        mockEndpoint.assertIsSatisfied();
         assertThat(thrown)
-                .cause()
-                .isInstanceOf(JsonParseException.class)
+                .cause().isInstanceOf(JsonParseException.class)
                 .message().isNotEmpty();
     }
 
     @Test
-    void testRequestStorageLocation_invalidUrlInResponse()
+    void testRequestStorageLocation_malformedUrlInResponse_doRetry() throws InterruptedException
     {
         // given
         StorageLocationRequest request = createStorageLocationRequestMock();
         String responseBodyWithInvalidUrl = createResponseBodyWith(STORAGE_LOCATION_PROPERTY, "invalidUrl");
         mockEndpointWillRespondWith(STATUS_CODE_201, responseBodyWithInvalidUrl);
+        mockEndpoint.expectedMessageCount(RETRY_ATTEMPTS_COUNT + 1);
 
         // when
         Throwable thrown = catchThrowable(() -> preSignedUrlRequester.requestStorageLocation(request));
 
         // then
+        mockEndpoint.assertIsSatisfied();
         assertThat(thrown)
-                .cause()
-                .isInstanceOf(LiveIngesterRuntimeException.class)
+                .cause().isInstanceOf(EndpointServerErrorException.class)
                 .hasMessageContaining("Parsing URL from response property failed!")
-                .rootCause()
-                .isInstanceOf(MalformedURLException.class)
+                .rootCause().isInstanceOf(MalformedURLException.class)
                 .message().isNotEmpty();
+    }
+
+    @Test
+    void testRequestStorageLocation_serverDown_doRetry() throws InterruptedException
+    {
+        // given
+        StorageLocationRequest request = createStorageLocationRequestMock();
+        mockEndpoint.whenAnyExchangeReceived(exchange -> exchange.setException(new UnknownHostException()));
+        mockEndpoint.expectedMessageCount(RETRY_ATTEMPTS_COUNT + 1);
+
+        // when
+        Throwable thrown = catchThrowable(() -> preSignedUrlRequester.requestStorageLocation(request));
+
+        // then
+        mockEndpoint.assertIsSatisfied();
+        assertThat(thrown)
+                .cause().isInstanceOf(UnknownHostException.class);
+    }
+
+    private IntegrationConfig.Properties integrationPropertiesOf(String endpoint, int retryAttempts)
+    {
+        return new IntegrationConfig.Properties(new IntegrationConfig.Storage(endpoint, new IntegrationConfig.Retry(retryAttempts, 0, 1, retryReasons)));
     }
 
     private StorageLocationRequest createStorageLocationRequestMock()

--- a/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/storage/connector/PreSignedUrlRequesterTest.java
+++ b/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/storage/connector/PreSignedUrlRequesterTest.java
@@ -73,7 +73,7 @@ class PreSignedUrlRequesterTest
     private static final String STORAGE_LOCATION = "http://dummy-url";
     private static final String RESPONSE_BODY_PATTERN = "{\"%s\": \"%s\"}";
     private static final String RESPONSE_BODY = createResponseBodyWith(STORAGE_LOCATION_PROPERTY, STORAGE_LOCATION);
-    private static final List<Class<? extends Throwable>> retryReasons = List.of(EndpointServerErrorException.class, UnknownHostException.class, MalformedURLException.class,
+    private static final List<Class<? extends Throwable>> RETRY_REASONS = List.of(EndpointServerErrorException.class, UnknownHostException.class, MalformedURLException.class,
             JsonEOFException.class, MismatchedInputException.class, HttpHostConnectException.class, NoHttpResponseException.class, MalformedChunkCodingException.class);
 
     CamelContext camelContext;
@@ -255,7 +255,7 @@ class PreSignedUrlRequesterTest
 
     private IntegrationConfig.Properties integrationPropertiesOf(String endpoint, int retryAttempts)
     {
-        return new IntegrationConfig.Properties(new IntegrationConfig.Storage(endpoint, new IntegrationConfig.Retry(retryAttempts, 0, 1, retryReasons)));
+        return new IntegrationConfig.Properties(new IntegrationConfig.Storage(endpoint, new IntegrationConfig.Retry(retryAttempts, 0, 1, RETRY_REASONS)));
     }
 
     private StorageLocationRequest createStorageLocationRequestMock()


### PR DESCRIPTION
[HxI LI] Upload pdf to S3 - PART II - added Camel-retry logic to PreSignedUrlRequester
https://alfresco.atlassian.net/browse/ACS-6380