### PR TITLE
ACS-6685 Refactor users into the general properties.

### DIFF
--- a/bulk-ingester/src/main/java/org/alfresco/hxi_connector/bulk_ingester/processor/mapper/AlfrescoNodeMapper.java
+++ b/bulk-ingester/src/main/java/org/alfresco/hxi_connector/bulk_ingester/processor/mapper/AlfrescoNodeMapper.java
@@ -50,6 +50,8 @@ public class AlfrescoNodeMapper
 {
     public static final String CONTENT_PROPERTY = "cm:content";
     public static final String TYPE_PROPERTY = "type";
+    public static final String CREATED_BY_PROPERTY = "createdBy";
+    public static final String MODIFIED_BY_PROPERTY = "modifiedBy";
     public static final String CREATED_AT_PROPERTY = "createdAt";
     private static final Set<String> PREDEFINED_PROPERTIES = Set.of(CONTENT_PROPERTY);
 
@@ -68,6 +70,8 @@ public class AlfrescoNodeMapper
         Map<String, Serializable> allProperties = calculateAllProperties(alfrescoNode);
 
         allProperties.put(TYPE_PROPERTY, type);
+        allProperties.put(CREATED_BY_PROPERTY, creatorId);
+        allProperties.put(MODIFIED_BY_PROPERTY, modifierId);
         allProperties.put(CREATED_AT_PROPERTY, createdAt);
 
         ContentInfo content = (ContentInfo) allProperties.get(CONTENT_PROPERTY);
@@ -76,8 +80,6 @@ public class AlfrescoNodeMapper
 
         return new Node(
                 nodeId,
-                creatorId,
-                modifierId,
                 aspectNames,
                 content,
                 customProperties);

--- a/bulk-ingester/src/main/java/org/alfresco/hxi_connector/bulk_ingester/processor/model/Node.java
+++ b/bulk-ingester/src/main/java/org/alfresco/hxi_connector/bulk_ingester/processor/model/Node.java
@@ -32,8 +32,6 @@ import java.util.Set;
 
 public record Node(
         String nodeId,
-        String creatorId,
-        String modifierId,
         Set<String> aspectNames,
         ContentInfo contentInfo,
         Map<String, Serializable> properties)

--- a/bulk-ingester/src/test/java/org/alfresco/hxi_connector/bulk_ingester/event/CamelNodePublisherIntegrationTest.java
+++ b/bulk-ingester/src/test/java/org/alfresco/hxi_connector/bulk_ingester/event/CamelNodePublisherIntegrationTest.java
@@ -68,8 +68,6 @@ public class CamelNodePublisherIntegrationTest extends ActiveMqIntegrationTestBa
         // given
         Node node = new Node(
                 "66326096-3bd6-412e-abbe-a07fbabf2fcc",
-                "admin",
-                "admin",
                 Set.of("ownable", "taggable"),
                 new ContentInfo(1000, "UTF-8", "application/pdf"),
                 Map.of(TYPE_PROPERTY, "file",
@@ -83,8 +81,6 @@ public class CamelNodePublisherIntegrationTest extends ActiveMqIntegrationTestBa
         String expectedEvent = """
                 {
                   "nodeId" : "66326096-3bd6-412e-abbe-a07fbabf2fcc",
-                  "creatorId" : "admin",
-                  "modifierId" : "admin",
                   "aspectNames" : [ "ownable", "taggable" ],
                   "contentInfo" : {
                     "contentSize" : 1000,

--- a/bulk-ingester/src/test/java/org/alfresco/hxi_connector/bulk_ingester/processor/mapper/AlfrescoNodeMapperTest.java
+++ b/bulk-ingester/src/test/java/org/alfresco/hxi_connector/bulk_ingester/processor/mapper/AlfrescoNodeMapperTest.java
@@ -32,6 +32,8 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 import static org.alfresco.hxi_connector.bulk_ingester.processor.mapper.AlfrescoNodeMapper.CREATED_AT_PROPERTY;
+import static org.alfresco.hxi_connector.bulk_ingester.processor.mapper.AlfrescoNodeMapper.CREATED_BY_PROPERTY;
+import static org.alfresco.hxi_connector.bulk_ingester.processor.mapper.AlfrescoNodeMapper.MODIFIED_BY_PROPERTY;
 import static org.alfresco.hxi_connector.bulk_ingester.processor.mapper.AlfrescoNodeMapper.TYPE_PROPERTY;
 
 import java.time.ZonedDateTime;
@@ -84,12 +86,11 @@ class AlfrescoNodeMapperTest
 
         // then
         assertEquals(NODE_UUID, node.nodeId());
-        assertEquals(CREATOR_ID, node.creatorId());
-        assertEquals(MODIFIER_ID, node.modifierId());
-        assertEquals(MODIFIER_ID, node.modifierId());
         assertEquals(Set.of(PREFIXED_ASPECT_TITLED), node.aspectNames());
         assertNull(node.contentInfo());
         assertEquals(Map.of(TYPE_PROPERTY, PREFIXED_TYPE_FOLDER,
+                CREATED_BY_PROPERTY, CREATOR_ID,
+                MODIFIED_BY_PROPERTY, MODIFIER_ID,
                 CREATED_AT_PROPERTY, CREATED_AT_TIMESTAMP), node.properties());
     }
 
@@ -114,6 +115,8 @@ class AlfrescoNodeMapperTest
         // then
         assertEquals(Map.of(namePropertyKey, namePropertyValue,
                 TYPE_PROPERTY, PREFIXED_TYPE_FOLDER,
+                CREATED_BY_PROPERTY, CREATOR_ID,
+                MODIFIED_BY_PROPERTY, MODIFIER_ID,
                 CREATED_AT_PROPERTY, CREATED_AT_TIMESTAMP), node.properties());
     }
 
@@ -137,6 +140,8 @@ class AlfrescoNodeMapperTest
         // then
         assertEquals(contentInfo, node.contentInfo());
         assertEquals(Map.of(TYPE_PROPERTY, PREFIXED_TYPE_FOLDER,
+                CREATED_BY_PROPERTY, CREATOR_ID,
+                MODIFIED_BY_PROPERTY, MODIFIER_ID,
                 CREATED_AT_PROPERTY, CREATED_AT_TIMESTAMP), node.properties());
     }
 
@@ -155,6 +160,8 @@ class AlfrescoNodeMapperTest
 
         // then
         assertEquals(Map.of(TYPE_PROPERTY, PREFIXED_TYPE_FOLDER,
+                CREATED_BY_PROPERTY, CREATOR_ID,
+                MODIFIED_BY_PROPERTY, MODIFIER_ID,
                 CREATED_AT_PROPERTY, CREATED_AT_TIMESTAMP), node.properties());
     }
 

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/bulk_ingester/BulkIngesterEventProcessor.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/bulk_ingester/BulkIngesterEventProcessor.java
@@ -26,7 +26,6 @@
 
 package org.alfresco.hxi_connector.live_ingester.adapters.messaging.bulk_ingester;
 
-import static org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.mapper.property.PropertyMappingHelper.CREATED_AT_PROPERTY;
 import static org.alfresco.hxi_connector.live_ingester.domain.usecase.metadata.model.EventType.CREATE;
 
 import java.io.Serializable;
@@ -59,14 +58,11 @@ public class BulkIngesterEventProcessor
     {
         Map<String, Serializable> properties = event.properties();
         Map<String, Serializable> customProperties = properties.entrySet().stream()
-                .filter(entry -> !entry.getKey().equals(CREATED_AT_PROPERTY))
                 .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
 
         IngestMetadataCommand ingestMetadataCommand = new IngestMetadataCommand(
                 event.nodeId(),
                 CREATE,
-                PropertyDelta.updated(event.creatorId()),
-                PropertyDelta.updated(event.modifierId()),
                 PropertyDelta.updated(event.aspectNames()),
                 mapToCustomPropertiesDelta(customProperties));
 

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/bulk_ingester/model/BulkIngesterEvent.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/bulk_ingester/model/BulkIngesterEvent.java
@@ -32,8 +32,6 @@ import java.util.Set;
 
 public record BulkIngesterEvent(
         String nodeId,
-        String creatorId,
-        String modifierId,
         Set<String> aspectNames,
         ContentInfo contentInfo,
         Map<String, Serializable> properties)

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/mapper/RepoEventMapper.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/mapper/RepoEventMapper.java
@@ -26,8 +26,6 @@
 
 package org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.mapper;
 
-import static java.util.Optional.ofNullable;
-
 import static org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.utils.EventUtils.getEventType;
 import static org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.utils.EventUtils.isEventTypeCreated;
 import static org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.utils.EventUtils.isEventTypeDeleted;
@@ -35,8 +33,6 @@ import static org.alfresco.hxi_connector.live_ingester.adapters.messaging.reposi
 import static org.alfresco.hxi_connector.live_ingester.domain.usecase.metadata.model.EventType.CREATE;
 import static org.alfresco.hxi_connector.live_ingester.domain.usecase.metadata.model.EventType.UPDATE;
 import static org.alfresco.hxi_connector.live_ingester.domain.utils.EnsureUtils.ensureThat;
-
-import java.util.function.Function;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -49,7 +45,6 @@ import org.alfresco.hxi_connector.live_ingester.domain.usecase.metadata.model.Ev
 import org.alfresco.repo.event.v1.model.DataAttributes;
 import org.alfresco.repo.event.v1.model.NodeResource;
 import org.alfresco.repo.event.v1.model.RepoEvent;
-import org.alfresco.repo.event.v1.model.UserInfo;
 
 @Component
 @RequiredArgsConstructor
@@ -72,8 +67,6 @@ public class RepoEventMapper
         return new IngestMetadataCommand(
                 event.getData().getResource().getId(),
                 eventType,
-                propertiesMapper.calculatePropertyDelta(event, node -> getUserId(node, NodeResource::getCreatedByUser)),
-                propertiesMapper.calculatePropertyDelta(event, node -> getUserId(node, NodeResource::getModifiedByUser)),
                 propertiesMapper.calculatePropertyDelta(event, NodeResource::getAspectNames),
                 propertiesMapper.calculateCustomPropertiesDelta(event));
     }
@@ -82,13 +75,5 @@ public class RepoEventMapper
     {
         ensureThat(isEventTypeDeleted(event), "Only delete events can be converted to delete commands");
         return new DeleteNodeCommand(event.getData().getResource().getId());
-    }
-
-    private String getUserId(NodeResource node, Function<NodeResource, UserInfo> userInfoGetter)
-    {
-        return ofNullable(node)
-                .map(userInfoGetter)
-                .map(UserInfo::getId)
-                .orElse(null);
     }
 }

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/mapper/property/PropertiesMapper.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/mapper/property/PropertiesMapper.java
@@ -30,6 +30,8 @@ import static java.util.Optional.ofNullable;
 import static java.util.function.Function.identity;
 
 import static org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.mapper.property.PropertyMappingHelper.calculateCreatedAtDelta;
+import static org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.mapper.property.PropertyMappingHelper.calculateCreatedByDelta;
+import static org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.mapper.property.PropertyMappingHelper.calculateModifiedByDelta;
 import static org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.mapper.property.PropertyMappingHelper.calculateNamePropertyDelta;
 import static org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.mapper.property.PropertyMappingHelper.calculateTypeDelta;
 import static org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.mapper.property.PropertyMappingHelper.isFieldUnchanged;
@@ -95,6 +97,8 @@ public class PropertiesMapper
         return Stream.of(propertyDeltas,
                 calculateNamePropertyDelta(event),
                 calculateTypeDelta(event),
+                calculateCreatedByDelta(event),
+                calculateModifiedByDelta(event),
                 calculateCreatedAtDelta(event))
                 .flatMap(identity())
                 .collect(Collectors.toSet());

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/mapper/property/PropertyMappingHelper.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/mapper/property/PropertyMappingHelper.java
@@ -43,12 +43,15 @@ import org.alfresco.hxi_connector.live_ingester.domain.usecase.metadata.model.Cu
 import org.alfresco.repo.event.v1.model.DataAttributes;
 import org.alfresco.repo.event.v1.model.NodeResource;
 import org.alfresco.repo.event.v1.model.RepoEvent;
+import org.alfresco.repo.event.v1.model.UserInfo;
 
 @NoArgsConstructor(access = PRIVATE)
 public class PropertyMappingHelper
 {
     public static final String NAME_PROPERTY_KEY = "cm:name";
     public static final String TYPE_PROPERTY = "type";
+    public static final String CREATED_BY_PROPERTY = "createdBy";
+    public static final String MODIFIED_BY_PROPERTY = "modifiedBy";
     public static final String CREATED_AT_PROPERTY = "createdAt";
 
     public static <T> Stream<CustomPropertyDelta<?>> calculatePropertyDelta(RepoEvent<DataAttributes<NodeResource>> event,
@@ -73,6 +76,24 @@ public class PropertyMappingHelper
     public static Stream<CustomPropertyDelta<?>> calculateTypeDelta(RepoEvent<DataAttributes<NodeResource>> event)
     {
         return calculatePropertyDelta(event, TYPE_PROPERTY, NodeResource::getNodeType);
+    }
+
+    public static Stream<CustomPropertyDelta<?>> calculateCreatedByDelta(RepoEvent<DataAttributes<NodeResource>> event)
+    {
+        return calculatePropertyDelta(event, CREATED_BY_PROPERTY, nodeResource -> getUserId(nodeResource, NodeResource::getCreatedByUser));
+    }
+
+    public static Stream<CustomPropertyDelta<?>> calculateModifiedByDelta(RepoEvent<DataAttributes<NodeResource>> event)
+    {
+        return calculatePropertyDelta(event, MODIFIED_BY_PROPERTY, nodeResource -> getUserId(nodeResource, NodeResource::getModifiedByUser));
+    }
+
+    private static String getUserId(NodeResource node, Function<NodeResource, UserInfo> userInfoGetter)
+    {
+        return ofNullable(node)
+                .map(userInfoGetter)
+                .map(UserInfo::getId)
+                .orElse(null);
     }
 
     public static Stream<CustomPropertyDelta<?>> calculateCreatedAtDelta(RepoEvent<DataAttributes<NodeResource>> event)

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/metadata/IngestMetadataCommand.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/metadata/IngestMetadataCommand.java
@@ -38,8 +38,6 @@ import org.alfresco.hxi_connector.live_ingester.domain.usecase.metadata.model.Pr
 public record IngestMetadataCommand(
         String nodeId,
         EventType eventType,
-        PropertyDelta<String> createdByUserWithId,
-        PropertyDelta<String> modifiedByUserWithId,
         PropertyDelta<Set<String>> aspectNames,
         Set<CustomPropertyDelta<?>> properties)
 {
@@ -47,8 +45,6 @@ public record IngestMetadataCommand(
     {
         ensureNotBlank(nodeId, "Node id cannot be blank");
         ensureNonNull(eventType, "Node %s event type cannot be null", nodeId);
-        ensureNonNull(createdByUserWithId, "Node %s created by user with nodeId delta cannot be null", nodeId);
-        ensureNonNull(modifiedByUserWithId, "Node %s modified by user with nodeId delta cannot be null", nodeId);
         ensureNonNull(aspectNames, "Node %s aspect names delta cannot be null", nodeId);
         ensureNonNull(properties, "Node %s custom properties delta cannot be null", nodeId);
     }

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/metadata/IngestMetadataCommandHandler.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/metadata/IngestMetadataCommandHandler.java
@@ -27,8 +27,6 @@
 package org.alfresco.hxi_connector.live_ingester.domain.usecase.metadata;
 
 import static org.alfresco.hxi_connector.live_ingester.domain.usecase.metadata.model.PredefinedNodeMetadataProperty.ASPECTS_NAMES;
-import static org.alfresco.hxi_connector.live_ingester.domain.usecase.metadata.model.PredefinedNodeMetadataProperty.CREATED_BY_USER_WITH_ID;
-import static org.alfresco.hxi_connector.live_ingester.domain.usecase.metadata.model.PredefinedNodeMetadataProperty.MODIFIED_BY_USER_WITH_ID;
 
 import java.util.List;
 import java.util.Optional;
@@ -54,8 +52,6 @@ public class IngestMetadataCommandHandler
         EventType eventType = command.eventType();
         UpdateNodeMetadataEvent updateMetadataEvent = new UpdateNodeMetadataEvent(command.nodeId(), eventType);
 
-        command.createdByUserWithId().applyAs(CREATED_BY_USER_WITH_ID, updateMetadataEvent);
-        command.modifiedByUserWithId().applyAs(MODIFIED_BY_USER_WITH_ID, updateMetadataEvent);
         command.aspectNames().applyAs(ASPECTS_NAMES, updateMetadataEvent);
 
         command.properties()

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/metadata/model/PredefinedNodeMetadataProperty.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/metadata/model/PredefinedNodeMetadataProperty.java
@@ -37,8 +37,6 @@ import org.alfresco.hxi_connector.live_ingester.domain.ports.ingestion_engine.No
 @Getter
 public class PredefinedNodeMetadataProperty<V>
 {
-    public static final PredefinedNodeMetadataProperty<String> CREATED_BY_USER_WITH_ID = new PredefinedNodeMetadataProperty<>("createdByUserWithId");
-    public static final PredefinedNodeMetadataProperty<String> MODIFIED_BY_USER_WITH_ID = new PredefinedNodeMetadataProperty<>("modifiedByUserWithId");
     public static final PredefinedNodeMetadataProperty<Set<String>> ASPECTS_NAMES = new PredefinedNodeMetadataProperty<>("aspectsNames");
 
     private final String name;

--- a/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/config/jackson/UpdateNodeMetadataEventSerializerTest.java
+++ b/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/config/jackson/UpdateNodeMetadataEventSerializerTest.java
@@ -29,10 +29,10 @@ package org.alfresco.hxi_connector.live_ingester.adapters.config.jackson;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import static org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.mapper.property.PropertyMappingHelper.CREATED_AT_PROPERTY;
+import static org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.mapper.property.PropertyMappingHelper.CREATED_BY_PROPERTY;
+import static org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.mapper.property.PropertyMappingHelper.MODIFIED_BY_PROPERTY;
 import static org.alfresco.hxi_connector.live_ingester.domain.usecase.metadata.model.EventType.CREATE;
 import static org.alfresco.hxi_connector.live_ingester.domain.usecase.metadata.model.EventType.UPDATE;
-import static org.alfresco.hxi_connector.live_ingester.domain.usecase.metadata.model.PredefinedNodeMetadataProperty.CREATED_BY_USER_WITH_ID;
-import static org.alfresco.hxi_connector.live_ingester.domain.usecase.metadata.model.PredefinedNodeMetadataProperty.MODIFIED_BY_USER_WITH_ID;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -69,7 +69,7 @@ class UpdateNodeMetadataEventSerializerTest
     {
         UpdateNodeMetadataEvent event = new UpdateNodeMetadataEvent(NODE_ID, CREATE)
                 .set(new NodeProperty<>(CREATED_AT_PROPERTY, 10000L))
-                .set(MODIFIED_BY_USER_WITH_ID.withValue("000-000-000"));
+                .set(new NodeProperty<>(MODIFIED_BY_PROPERTY, "000-000-000"));
 
         String expectedJson = """
                 {
@@ -77,7 +77,7 @@ class UpdateNodeMetadataEventSerializerTest
                   "eventType": "create",
                   "properties": {
                     "createdAt": 10000,
-                    "modifiedByUserWithId": "000-000-000"
+                    "modifiedBy": "000-000-000"
                   }
                 }""".formatted(NODE_ID);
         String actualJson = serialize(event);
@@ -90,13 +90,13 @@ class UpdateNodeMetadataEventSerializerTest
     {
         UpdateNodeMetadataEvent event = new UpdateNodeMetadataEvent(NODE_ID, UPDATE)
                 .unset(CREATED_AT_PROPERTY)
-                .unset(MODIFIED_BY_USER_WITH_ID.getName());
+                .unset(MODIFIED_BY_PROPERTY);
 
         String expectedJson = """
                 {
                   "objectId": "%s",
                   "eventType": "update",
-                  "removedProperties": [ "createdAt", "modifiedByUserWithId" ]
+                  "removedProperties": [ "createdAt", "modifiedBy" ]
                 }""".formatted(NODE_ID);
         String actualJson = serialize(event);
 
@@ -107,16 +107,16 @@ class UpdateNodeMetadataEventSerializerTest
     public void canCopeWithNullUsers()
     {
         UpdateNodeMetadataEvent event = new UpdateNodeMetadataEvent(NODE_ID, CREATE)
-                .set(CREATED_BY_USER_WITH_ID.withValue(null))
-                .set(MODIFIED_BY_USER_WITH_ID.withValue(null));
+                .set(new NodeProperty<>(CREATED_BY_PROPERTY, null))
+                .set(new NodeProperty<>(MODIFIED_BY_PROPERTY, null));
 
         String expectedJson = """
                 {
                   "objectId": "%s",
                   "eventType": "create",
                   "properties": {
-                    "createdByUserWithId": null,
-                    "modifiedByUserWithId": null
+                    "createdBy": null,
+                    "modifiedBy": null
                   }
                 }""".formatted(NODE_ID);
         String actualJson = serialize(event);

--- a/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/bulk_ingester/BulkIngesterEventProcessorTest.java
+++ b/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/bulk_ingester/BulkIngesterEventProcessorTest.java
@@ -77,13 +77,10 @@ class BulkIngesterEventProcessorTest
         Map<String, Serializable> properties = Map.of(
                 "cm:name", "test folder",
                 "cm:title", "test folder title",
-                TYPE_PROPERTY, NODE_TYPE,
-                CREATED_AT_PROPERTY, CREATED_AT);
+                TYPE_PROPERTY, NODE_TYPE);
 
         BulkIngesterEvent bulkIngesterEvent = new BulkIngesterEvent(
                 NODE_ID,
-                CREATOR_ID,
-                MODIFIER_ID,
                 ASPECT_NAMES,
                 null,
                 properties);
@@ -95,8 +92,6 @@ class BulkIngesterEventProcessorTest
         IngestMetadataCommand expectedCommand = new IngestMetadataCommand(
                 NODE_ID,
                 CREATE,
-                PropertyDelta.updated(CREATOR_ID),
-                PropertyDelta.updated(MODIFIER_ID),
                 PropertyDelta.updated(ASPECT_NAMES),
                 Set.of(
                         CustomPropertyDelta.updated(TYPE_PROPERTY, NODE_TYPE),
@@ -119,8 +114,6 @@ class BulkIngesterEventProcessorTest
 
         BulkIngesterEvent bulkIngesterEvent = new BulkIngesterEvent(
                 NODE_ID,
-                CREATOR_ID,
-                MODIFIER_ID,
                 ASPECT_NAMES,
                 contentInfo,
                 Map.of(TYPE_PROPERTY, NODE_TYPE,

--- a/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/mapper/RepoEventMapperTest.java
+++ b/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/mapper/RepoEventMapperTest.java
@@ -125,8 +125,6 @@ class RepoEventMapperTest
                 NODE_ID,
                 CREATE,
                 regularPropertyDelta,
-                regularPropertyDelta,
-                regularPropertyDelta,
                 Collections.emptySet());
 
         assertEquals(expectedEvent, actualEvent);

--- a/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/domain/ports/ingestion_engine/UpdateNodeMetadataEventTest.java
+++ b/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/domain/ports/ingestion_engine/UpdateNodeMetadataEventTest.java
@@ -30,8 +30,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import static org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.mapper.property.PropertyMappingHelper.CREATED_BY_PROPERTY;
 import static org.alfresco.hxi_connector.live_ingester.domain.usecase.metadata.model.EventType.UPDATE;
-import static org.alfresco.hxi_connector.live_ingester.domain.usecase.metadata.model.PredefinedNodeMetadataProperty.CREATED_BY_USER_WITH_ID;
 
 import org.junit.jupiter.api.Test;
 
@@ -45,8 +45,8 @@ class UpdateNodeMetadataEventTest
         // given
         UpdateNodeMetadataEvent updateNodeMetadataEvent = new UpdateNodeMetadataEvent(NODE_ID, UPDATE);
 
-        NodeProperty<String> name1 = CREATED_BY_USER_WITH_ID.withValue("admin");
-        NodeProperty<String> name2 = CREATED_BY_USER_WITH_ID.withValue("hruser");
+        NodeProperty<String> name1 = new NodeProperty<>(CREATED_BY_PROPERTY, "admin");
+        NodeProperty<String> name2 = new NodeProperty<>(CREATED_BY_PROPERTY, "hruser");
 
         // when
         updateNodeMetadataEvent.set(name1);
@@ -64,11 +64,11 @@ class UpdateNodeMetadataEventTest
         UpdateNodeMetadataEvent updateNodeMetadataEvent = new UpdateNodeMetadataEvent(NODE_ID, UPDATE);
 
         // when
-        updateNodeMetadataEvent.unset(CREATED_BY_USER_WITH_ID.getName());
-        updateNodeMetadataEvent.unset(CREATED_BY_USER_WITH_ID.getName());
+        updateNodeMetadataEvent.unset(CREATED_BY_PROPERTY);
+        updateNodeMetadataEvent.unset(CREATED_BY_PROPERTY);
 
         // then
         assertEquals(1, updateNodeMetadataEvent.getMetadataPropertiesToUnset().size());
-        assertTrue(updateNodeMetadataEvent.getMetadataPropertiesToUnset().contains(CREATED_BY_USER_WITH_ID.getName()));
+        assertTrue(updateNodeMetadataEvent.getMetadataPropertiesToUnset().contains(CREATED_BY_PROPERTY));
     }
 }

--- a/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/CreateRequestIntegrationTest.java
+++ b/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/CreateRequestIntegrationTest.java
@@ -100,8 +100,8 @@ public class CreateRequestIntegrationTest extends E2ETestBase
                       "aspectsNames" : [ "cm:versionable", "cm:auditable" ],
                       "cm:name" : "purchase-order-scan.pdf",
                       "type" : "cm:content",
-                      "createdByUserWithId" : "admin",
-                      "modifiedByUserWithId" : "admin"
+                      "createdBy" : "admin",
+                      "modifiedBy" : "admin"
                     }
                  }""";
         containerSupport.expectHxIngestMessageReceived(expectedBody);

--- a/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/UpdateRequestIntegrationTest.java
+++ b/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/UpdateRequestIntegrationTest.java
@@ -110,7 +110,7 @@ public class UpdateRequestIntegrationTest extends E2ETestBase
                   "properties" : {
                     "cm:title" : "Purchase Order",
                     "aspectsNames" : [ "cm:versionable", "cm:author", "cm:titled" ],
-                    "modifiedByUserWithId" : "abeecher"
+                    "modifiedBy" : "abeecher"
                   },
                   "removedProperties" : [ "cm:versionType", "cm:description" ]
                 }""";
@@ -410,5 +410,65 @@ public class UpdateRequestIntegrationTest extends E2ETestBase
                 }""";
 
         return repoEvent.formatted(properties, propertiesBefore);
+    }
+
+    @Test
+    void testLogInEvent()
+    {
+        // given
+        containerSupport.prepareHxInsightToReturnSuccess();
+
+        String repoEvent = """
+                {
+                  "specversion": "1.0",
+                  "type": "org.alfresco.event.node.Updated",
+                  "id": "621573f5-0fb4-46dd-ab1a-88f83c0e1f2b",
+                  "source": "/6cac945d-0919-47cc-ade7-8645e65c4371",
+                  "time": "2024-01-09T11:14:33.615Z",
+                  "dataschema": "https://api.alfresco.com/schema/event/repo/v1/nodeUpdated",
+                  "datacontenttype": "application/json",
+                  "data": {
+                    "eventGroupId": "a7a1ef25-2398-4fb9-8178-f3a6ff6d5ed0",
+                    "resource": {
+                      "@type": "NodeResource",
+                      "id": "321d84e3-a5fe-431e-92f5-f8e09480305e",
+                      "name": "321d84e3-a5fe-431e-92f5-f8e09480305e",
+                      "nodeType": "cm:person",
+                      "createdByUser": null,
+                      "createdAt": null,
+                      "modifiedByUser": null,
+                      "modifiedAt": null,
+                      "content": null,
+                      "properties": {
+                        "cm:homeFolderProvider": "bootstrapHomeFolderProvider",
+                        "cm:homeFolder": {"storeRef": {"protocol": "workspace", "identifier": "SpacesStore"}, "id": "7f1fa040-e840-40c6-a8a0-da457aca2473"},
+                        "sys:cascadeCRC": 1040368885,
+                        "cm:lastName": ""
+                      },
+                      "aspectNames": [ "cm:preferences", "cm:ownable" ],
+                      "isFolder": false,
+                      "isFile": false
+                    },
+                    "resourceBefore": {
+                      "properties": {
+                        "cm:preferenceValues": null
+                      },
+                      "aspectNames": [ "cm:ownable" ]
+                    }
+                  }
+                }""";
+        // when
+        containerSupport.raiseRepoEvent(repoEvent);
+
+        // then
+        String expectedBody = """
+                {
+                  "objectId" : "321d84e3-a5fe-431e-92f5-f8e09480305e",
+                  "eventType" : "update",
+                  "properties" : {
+                    "aspectsNames" : [ "cm:preferences", "cm:ownable" ]
+                  }
+                }""";
+        containerSupport.expectHxIngestMessageReceived(expectedBody);
     }
 }

--- a/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/metadata/model/PredefinedNodeMetadataPropertyTest.java
+++ b/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/metadata/model/PredefinedNodeMetadataPropertyTest.java
@@ -28,6 +28,8 @@ package org.alfresco.hxi_connector.live_ingester.domain.usecase.metadata.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import static org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.mapper.property.PropertyMappingHelper.CREATED_BY_PROPERTY;
+
 import org.junit.jupiter.api.Test;
 
 import org.alfresco.hxi_connector.live_ingester.domain.ports.ingestion_engine.NodeProperty;
@@ -42,10 +44,10 @@ class PredefinedNodeMetadataPropertyTest
         String name = "test user";
 
         // when
-        NodeProperty<String> nodeProperty = PredefinedNodeMetadataProperty.CREATED_BY_USER_WITH_ID.withValue(name);
+        NodeProperty<String> nodeProperty = new NodeProperty<>(CREATED_BY_PROPERTY, name);
 
         // then
-        assertEquals(PredefinedNodeMetadataProperty.CREATED_BY_USER_WITH_ID.getName(), nodeProperty.name());
+        assertEquals(CREATED_BY_PROPERTY, nodeProperty.name());
         assertEquals(name, nodeProperty.value());
     }
 }


### PR DESCRIPTION
Replace unit test for null users in log in event with e2e test, since we've removed the special code to handle this case.