### PR TITLE
NO_TICKET: Adding spotless license header config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
   pre_commit:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v1.35.2
       - uses: Alfresco/alfresco-build-tools/.github/actions/pre-commit@v1.35.2
 

--- a/license-header
+++ b/license-header
@@ -1,0 +1,25 @@
+/*
+ * #%L
+ * Alfresco HX Insight Connector
+ * %%
+ * Copyright (C) $YEAR Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */

--- a/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/filter/TemporaryLicenseTestClass.java
+++ b/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/filter/TemporaryLicenseTestClass.java
@@ -1,0 +1,4 @@
+package org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.filter;
+
+public class TemporaryLicenseTestClass {
+}

--- a/pom.xml
+++ b/pom.xml
@@ -349,6 +349,11 @@
                             <includes>
                                 <include>src/*/java/**/*.java</include>
                             </includes>
+                            <ratchetFrom>origin/master</ratchetFrom> <!-- this means that the whole spottless check/apply will run only against differences to origin/master branch-->
+                            <licenseHeader>
+                                <file>license-header</file>
+                                <delimiter>package</delimiter>  <!-- content until first occurrence of the delimiter regex will be interpreted as header section -->
+                            </licenseHeader>
                             <eclipse>
                                 <file>alfresco-formatter.xml</file>
                             </eclipse>

--- a/pom.xml
+++ b/pom.xml
@@ -349,7 +349,7 @@
                             <includes>
                                 <include>src/*/java/**/*.java</include>
                             </includes>
-                            <ratchetFrom>origin/master</ratchetFrom> <!-- this means that the whole spottless check/apply will run only against differences to origin/master branch-->
+                            <ratchetFrom>ORIG_HEAD</ratchetFrom> <!-- this means that the whole spottless check/apply will run only against differences to ORIG_HEAD -->
                             <licenseHeader>
                                 <file>license-header</file>
                                 <delimiter>package</delimiter>  <!-- content until first occurrence of the delimiter regex will be interpreted as header section -->


### PR DESCRIPTION
This config will introduce 2 changes in spotless apply/check:
1. Whole run will be executed against only the files which differ from `origin/master` branch.
2. All files will be updated with header from `license-header` file in root of the project. If the file doesn't have any header - it will just be added, If there already is a header, then if the year is not current year it will be updated to `<previous_year_value>-<current_year>`, e.g., from `2023` to `2023-2024`.
For details see https://github.com/diffplug/spotless/tree/main/plugin-maven#license-header and https://github.com/diffplug/spotless/tree/main/plugin-maven#ratchet
