### PR TITLE
ACS-6869: Fixing filter logic.

### DIFF
--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/RequestFiltersIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/RequestFiltersIntegrationTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco HX Insight Connector
  * %%
- * Copyright (C) 2024 Alfresco Software Limited
+ * Copyright (C) 2023 - 2024 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * If the software was purchased under a paid Alfresco license, the terms of
@@ -477,16 +477,16 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                 {
                   "specversion": "1.0",
                   "type": "org.alfresco.event.node.Created",
-                  "id": "368818d9-dddd-4b8b-8eab-e050253d7f03",
+                  "id": "368818d9-dddd-4b8b-8eab-e050253d7f07",
                   "source": "/08d9b620-48de-4247-8f33-360988d3b19b",
                   "time": "2021-01-21T11:14:16.42372Z",
                   "dataschema": "https://api.alfresco.com/schema/event/repo/v1/nodeCreated",
                   "datacontenttype": "application/json",
                   "data": {
-                    "eventGroupId": "4004ca99-9d2a-400d-9d80-8f840e223503",
+                    "eventGroupId": "4004ca99-9d2a-400d-9d80-8f840e223507",
                     "resource": {
                       "@type": "NodeResource",
-                      "id": "d71dd823-82c7-477c-8490-04cb0e826e03",
+                      "id": "d71dd823-82c7-477c-8490-04cb0e826e07",
                       "primaryHierarchy": [ "5f355d16-f824-4173-bf4b-b1ec37ef5549", "93f7edf5-e4d8-4749-9b4c-e45097e2e19d" ],
                       "name": "purchase-order-scan.pdf",
                       "nodeType": "cm:content",
@@ -535,16 +535,16 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                 {
                   "specversion": "1.0",
                   "type": "org.alfresco.event.node.Created",
-                  "id": "368818d9-dddd-4b8b-8eab-e050253d7f03",
+                  "id": "368818d9-dddd-4b8b-8eab-e050253d7f08",
                   "source": "/08d9b620-48de-4247-8f33-360988d3b19b",
                   "time": "2021-01-21T11:14:16.42372Z",
                   "dataschema": "https://api.alfresco.com/schema/event/repo/v1/nodeCreated",
                   "datacontenttype": "application/json",
                   "data": {
-                    "eventGroupId": "4004ca99-9d2a-400d-9d80-8f840e223503",
+                    "eventGroupId": "4004ca99-9d2a-400d-9d80-8f840e223508",
                     "resource": {
                       "@type": "NodeResource",
-                      "id": "d71dd823-82c7-477c-8490-04cb0e826e03",
+                      "id": "d71dd823-82c7-477c-8490-04cb0e826e08",
                       "primaryHierarchy": [ "5f355d16-f824-4173-bf4b-b1ec37ef5549", "93f7edf5-e4d8-4749-9b4c-e45097e2e19d" ],
                       "name": "purchase-order-scan.pdf",
                       "nodeType": "cm:content",

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/RequestFiltersIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/RequestFiltersIntegrationTest.java
@@ -45,7 +45,6 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
         // given
         containerSupport.prepareHxInsightToReturnSuccess();
 
-        // when
         String repoEvent = """
                 {
                   "specversion": "1.0",
@@ -91,6 +90,8 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                     "resourceDeniedAuthorities": []
                   }
                 }""";
+
+        // when
         containerSupport.raiseRepoEvent(repoEvent);
 
         // then
@@ -127,9 +128,6 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
     void testCreateRequestWithAspectInDeniedFilter()
     {
         // given
-        containerSupport.prepareHxInsightToReturnSuccess();
-
-        // when
         String repoEvent = """
                 {
                   "specversion": "1.0",
@@ -175,6 +173,8 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                     "resourceDeniedAuthorities": []
                   }
                 }""";
+
+        // when
         containerSupport.raiseRepoEvent(repoEvent);
 
         // then
@@ -185,9 +185,6 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
     void testCreateRequestWithAspectNotPresentInAllowedFilter()
     {
         // given
-        containerSupport.prepareHxInsightToReturnSuccess();
-
-        // when
         String repoEvent = """
                 {
                   "specversion": "1.0",
@@ -233,6 +230,8 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                     "resourceDeniedAuthorities": []
                   }
                 }""";
+
+        // when
         containerSupport.raiseRepoEvent(repoEvent);
 
         // then
@@ -304,6 +303,7 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                     }
                   }
                 }""";
+
         // when
         containerSupport.raiseRepoEvent(repoEvent);
 
@@ -326,8 +326,6 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
     void testUpdateRequestWithAspectInDeniedFilter()
     {
         // given
-        containerSupport.prepareHxInsightToReturnSuccess();
-
         String repoEvent = """
                 {
                   "specversion": "1.0",
@@ -425,7 +423,7 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                         "id": "abeecher",
                         "displayName": "Alice Beecher"
                       },
-                      "modifiedAt": "2024-03-66T10:29:42.529Z",
+                      "modifiedAt": "2024-03-06T10:29:42.529Z",
                       "content": {
                         "mimeType": "application/pdf",
                         "sizeInBytes": 531152,
@@ -459,11 +457,23 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                     }
                   }
                 }""";
+
         // when
         containerSupport.raiseRepoEvent(repoEvent);
 
         // then
-        containerSupport.expectNoHxIngestMessagesReceived();
+        String expectedBody = """
+                {
+                  "objectId": "d71dd823-82c7-477c-8490-04cb0e826e06",
+                  "eventType": "update",
+                  "properties": {
+                    "cm:title": {"value": "Purchase Order"},
+                    "aspectsNames": {"value" : [ "cm:versionable", "cm:author", "cm:titled", "cm:classifiable" ]},
+                    "modifiedBy": {"value": "abeecher"}
+                  },
+                  "removedProperties": ["cm:versionType", "cm:description"]
+                }""";
+        containerSupport.expectHxIngestMessageReceived(expectedBody);
     }
 
     @Test
@@ -472,7 +482,6 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
         // given
         containerSupport.prepareHxInsightToReturnSuccess();
 
-        // when
         String repoEvent = """
                 {
                   "specversion": "1.0",
@@ -518,6 +527,8 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                     "resourceDeniedAuthorities": []
                   }
                 }""";
+
+        // when
         containerSupport.raiseRepoEvent(repoEvent);
 
         // then
@@ -528,9 +539,6 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
     void testCreateRequestWithNoAspectsInEvent()
     {
         // given
-        containerSupport.prepareHxInsightToReturnSuccess();
-
-        // when
         String repoEvent = """
                 {
                   "specversion": "1.0",
@@ -575,6 +583,8 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                     "resourceDeniedAuthorities": []
                   }
                 }""";
+
+        // when
         containerSupport.raiseRepoEvent(repoEvent);
 
         // then

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/util/ContainerSupport.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/util/ContainerSupport.java
@@ -164,12 +164,24 @@ public class ContainerSupport
                 .withHeader(AUTHORIZATION, equalTo(AuthUtils.createAuthorizationHeader()))
                 .withHeader(CONTENT_TYPE, equalTo("application/json"))
                 .withRequestBody(equalToJson(expectedBody))));
+        resetWireMock();
     }
 
     @SneakyThrows
     public void expectNoHxIngestMessagesReceived()
     {
         getHxInsightMock().verifyThat(exactly(0), postRequestedFor(urlPathEqualTo(HX_INSIGHT_INGEST_ENDPOINT)));
+        resetWireMock();
+    }
+
+    private static void resetWireMock()
+    {
+        WireMock.reset();
+        WireMock.resetAllRequests();
+        getHxInsightMock().resetRequests();
+        getHxInsightMock().resetMappings();
+        getSfsMock().resetRequests();
+        getSfsMock().resetMappings();
     }
 
     @SneakyThrows

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/util/ContainerSupport.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/util/ContainerSupport.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco HX Insight Connector
  * %%
- * Copyright (C) 2024 Alfresco Software Limited
+ * Copyright (C) 2023 - 2024 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * If the software was purchased under a paid Alfresco license, the terms of

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/util/E2ETestBase.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/util/E2ETestBase.java
@@ -173,6 +173,11 @@ public class E2ETestBase
     public void reset()
     {
         WireMock.reset();
+        WireMock.resetAllRequests();
+        hxInsightMock.resetRequests();
+        hxInsightMock.resetMappings();
+        sfsMock.resetRequests();
+        sfsMock.resetMappings();
         containerSupport.clearATSQueue();
     }
 

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/util/E2ETestBase.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/util/E2ETestBase.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco HX Insight Connector
  * %%
- * Copyright (C) 2024 Alfresco Software Limited
+ * Copyright (C) 2023 - 2024 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * If the software was purchased under a paid Alfresco license, the terms of

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/filter/AspectFilterApplier.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/filter/AspectFilterApplier.java
@@ -59,18 +59,7 @@ public class AspectFilterApplier implements NodeFilterApplier
 
     private boolean isAllowed(Set<String> aspectNames, List<String> allowed)
     {
-        if (allowed.isEmpty())
-        {
-            return true;
-        }
-        else if (aspectNames.isEmpty())
-        {
-            return false;
-        }
-        else
-        {
-            return new HashSet<>(allowed).containsAll(aspectNames);
-        }
+        return allowed.isEmpty() || !aspectNames.isEmpty() && new HashSet<>(allowed).containsAll(aspectNames);
     }
 
     private boolean isDenied(Set<String> aspectNames, List<String> denied)

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/filter/AspectFilterApplier.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/filter/AspectFilterApplier.java
@@ -26,7 +26,6 @@
 
 package org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.filter;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -34,6 +33,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.SetUtils;
 import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
 
 import org.alfresco.hxi_connector.live_ingester.adapters.config.properties.Filter;
 import org.alfresco.repo.event.v1.model.DataAttributes;
@@ -59,7 +59,7 @@ public class AspectFilterApplier implements NodeFilterApplier
 
     private boolean isAllowed(Set<String> aspectNames, List<String> allowed)
     {
-        return allowed.isEmpty() || !aspectNames.isEmpty() && new HashSet<>(allowed).containsAll(aspectNames);
+        return CollectionUtils.isEmpty(allowed) || allowed.stream().anyMatch(aspectNames::contains);
     }
 
     private boolean isDenied(Set<String> aspectNames, List<String> denied)

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/filter/AspectFilterApplier.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/filter/AspectFilterApplier.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco HX Insight Connector
  * %%
- * Copyright (C) 2024 Alfresco Software Limited
+ * Copyright (C) 2023 - 2024 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * If the software was purchased under a paid Alfresco license, the terms of
@@ -26,6 +26,7 @@
 
 package org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.filter;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -33,7 +34,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.SetUtils;
 import org.springframework.stereotype.Component;
-import org.springframework.util.CollectionUtils;
 
 import org.alfresco.hxi_connector.live_ingester.adapters.config.properties.Filter;
 import org.alfresco.repo.event.v1.model.DataAttributes;
@@ -59,7 +59,18 @@ public class AspectFilterApplier implements NodeFilterApplier
 
     private boolean isAllowed(Set<String> aspectNames, List<String> allowed)
     {
-        return CollectionUtils.isEmpty(allowed) || allowed.stream().anyMatch(aspectNames::contains);
+        if (allowed.isEmpty())
+        {
+            return true;
+        }
+        else if (aspectNames.isEmpty())
+        {
+            return false;
+        }
+        else
+        {
+            return new HashSet<>(allowed).containsAll(aspectNames);
+        }
     }
 
     private boolean isDenied(Set<String> aspectNames, List<String> denied)

--- a/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/filter/AspectFilterApplierTest.java
+++ b/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/filter/AspectFilterApplierTest.java
@@ -53,6 +53,10 @@ import org.alfresco.repo.event.v1.model.RepoEvent;
 class AspectFilterApplierTest
 {
 
+    private static final String CM_ASPECT_1 = "cm:aspect1";
+    private static final String CM_ASPECT_2 = "cm:aspect2";
+    private static final String CM_ASPECT_3 = "cm:aspect3";
+    private static final String CM_ASPECT_4 = "cm:aspect4";
     @Mock
     private RepoEvent<DataAttributes<NodeResource>> mockRepoEvent;
     @Mock
@@ -78,7 +82,7 @@ class AspectFilterApplierTest
     @Test
     void shouldNotFilterOutNonEmptyAspectsWhenEmptyAllowedAndEmptyDenied()
     {
-        given(mockResource.getAspectNames()).willReturn(Set.of("aspect1"));
+        given(mockResource.getAspectNames()).willReturn(Set.of(CM_ASPECT_1));
         given(mockAspect.allow()).willReturn(emptyList());
         given(mockAspect.deny()).willReturn(emptyList());
 
@@ -92,9 +96,8 @@ class AspectFilterApplierTest
     @Test
     void shouldFilterOutWhenAspectsEmptyAndNonEmptyAllowedAndEmptyDenied()
     {
-        final String aspect1 = "cm:aspect1";
         given(mockResource.getAspectNames()).willReturn(emptySet());
-        given(mockAspect.allow()).willReturn(List.of(aspect1));
+        given(mockAspect.allow()).willReturn(List.of(CM_ASPECT_1));
         given(mockAspect.deny()).willReturn(emptyList());
 
         // when
@@ -121,9 +124,8 @@ class AspectFilterApplierTest
     @Test
     void shouldFilterOutWhenAspectsNullAndNonEmptyAllowedAndEmptyDenied()
     {
-        final String aspect1 = "cm:aspect1";
         given(mockResource.getAspectNames()).willReturn(null);
-        given(mockAspect.allow()).willReturn(List.of(aspect1));
+        given(mockAspect.allow()).willReturn(List.of(CM_ASPECT_1));
         given(mockAspect.deny()).willReturn(emptyList());
 
         // when
@@ -148,29 +150,25 @@ class AspectFilterApplierTest
     }
 
     @Test
-    void shouldNotFilterOutWhenAspectInAllowedAndEmptyDenied()
+    void shouldNotFilterOutWhenAtLeastOneAspectInAllowedAndEmptyDenied()
     {
-        final String aspect1 = "cm:aspect1";
-        final String aspect2 = "cm:aspect2";
-        given(mockResource.getAspectNames()).willReturn(Set.of(aspect1, aspect2));
-        given(mockAspect.allow()).willReturn(List.of(aspect1));
+        given(mockResource.getAspectNames()).willReturn(Set.of(CM_ASPECT_1, CM_ASPECT_2));
+        given(mockAspect.allow()).willReturn(List.of(CM_ASPECT_1));
         given(mockAspect.deny()).willReturn(emptyList());
 
         // when
         boolean result = objectUnderTest.applyFilter(mockRepoEvent, mockFilter);
 
         // then
-        assertFalse(result);
+        assertTrue(result);
     }
 
     @Test
     void shouldNotFilterOutWhenEmptyAllowedAndAspectNotInDenied()
     {
-        final String aspect1 = "cm:aspect1";
-        final String aspect2 = "cm:aspect2";
-        given(mockResource.getAspectNames()).willReturn(Set.of(aspect1));
+        given(mockResource.getAspectNames()).willReturn(Set.of(CM_ASPECT_1));
         given(mockAspect.allow()).willReturn(emptyList());
-        given(mockAspect.deny()).willReturn(List.of(aspect2));
+        given(mockAspect.deny()).willReturn(List.of(CM_ASPECT_2));
 
         // when
         boolean result = objectUnderTest.applyFilter(mockRepoEvent, mockFilter);
@@ -182,11 +180,9 @@ class AspectFilterApplierTest
     @Test
     void shouldNotFilterOutWhenAspectInAllowedAndAspectNotInDenied()
     {
-        final String aspect1 = "cm:aspect1";
-        final String aspect2 = "cm:aspect2";
-        given(mockResource.getAspectNames()).willReturn(Set.of(aspect1));
-        given(mockAspect.allow()).willReturn(List.of(aspect1));
-        given(mockAspect.deny()).willReturn(List.of(aspect2));
+        given(mockResource.getAspectNames()).willReturn(Set.of(CM_ASPECT_1));
+        given(mockAspect.allow()).willReturn(List.of(CM_ASPECT_1));
+        given(mockAspect.deny()).willReturn(List.of(CM_ASPECT_2));
 
         // when
         boolean result = objectUnderTest.applyFilter(mockRepoEvent, mockFilter);
@@ -198,11 +194,9 @@ class AspectFilterApplierTest
     @Test
     void shouldFilterOutWhenAspectInAllowedAndAspectInDenied()
     {
-        final String aspect1 = "cm:aspect1";
-        final String aspect2 = "cm:aspect2";
-        given(mockResource.getAspectNames()).willReturn(Set.of(aspect1, aspect2));
-        given(mockAspect.allow()).willReturn(List.of(aspect1));
-        given(mockAspect.deny()).willReturn(List.of(aspect2));
+        given(mockResource.getAspectNames()).willReturn(Set.of(CM_ASPECT_1, CM_ASPECT_2));
+        given(mockAspect.allow()).willReturn(List.of(CM_ASPECT_1));
+        given(mockAspect.deny()).willReturn(List.of(CM_ASPECT_2));
 
         // when
         boolean result = objectUnderTest.applyFilter(mockRepoEvent, mockFilter);
@@ -214,11 +208,8 @@ class AspectFilterApplierTest
     @Test
     void shouldFilterOutWhenAspectNotAllowedAndEmptyDenied()
     {
-        final String aspect1 = "cm:aspect1";
-        final String aspect2 = "cm:aspect2";
-        final String aspect3 = "cm:aspect3";
-        given(mockResource.getAspectNames()).willReturn(Set.of(aspect1, aspect2));
-        given(mockAspect.allow()).willReturn(List.of(aspect3));
+        given(mockResource.getAspectNames()).willReturn(Set.of(CM_ASPECT_1, CM_ASPECT_2));
+        given(mockAspect.allow()).willReturn(List.of(CM_ASPECT_3));
         given(mockAspect.deny()).willReturn(emptyList());
 
         // when
@@ -231,16 +222,28 @@ class AspectFilterApplierTest
     @Test
     void shouldFilterOutWhenEmptyAllowedAndAspectInDenied()
     {
-        final String aspect2 = "cm:aspect2";
-        final String aspect3 = "cm:aspect3";
-        given(mockResource.getAspectNames()).willReturn(Set.of(aspect2, aspect3));
+        given(mockResource.getAspectNames()).willReturn(Set.of(CM_ASPECT_2, CM_ASPECT_3));
         given(mockAspect.allow()).willReturn(emptyList());
-        given(mockAspect.deny()).willReturn(List.of(aspect3));
+        given(mockAspect.deny()).willReturn(List.of(CM_ASPECT_3));
 
         // when
         boolean result = objectUnderTest.applyFilter(mockRepoEvent, mockFilter);
 
         // then
         assertFalse(result);
+    }
+
+    @Test
+    void shouldNotFilterOutWhenAtLeastOneAspectInAllowedAndAspectNotInDenied()
+    {
+        given(mockResource.getAspectNames()).willReturn(Set.of(CM_ASPECT_1, CM_ASPECT_4));
+        given(mockAspect.allow()).willReturn(List.of(CM_ASPECT_1, CM_ASPECT_2));
+        given(mockAspect.deny()).willReturn(List.of(CM_ASPECT_3));
+
+        // when
+        boolean result = objectUnderTest.applyFilter(mockRepoEvent, mockFilter);
+
+        // then
+        assertTrue(result);
     }
 }

--- a/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/filter/AspectFilterApplierTest.java
+++ b/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/filter/AspectFilterApplierTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco HX Insight Connector
  * %%
- * Copyright (C) 2024 Alfresco Software Limited
+ * Copyright (C) 2023 - 2024 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * If the software was purchased under a paid Alfresco license, the terms of
@@ -160,7 +160,7 @@ class AspectFilterApplierTest
         boolean result = objectUnderTest.applyFilter(mockRepoEvent, mockFilter);
 
         // then
-        assertTrue(result);
+        assertFalse(result);
     }
 
     @Test


### PR DESCRIPTION
This PR fixes aspect filtering logic for a case when not all aspects present on a node are present in allow list (but some are).
That seemed to be a problem with integration test (as the unit test tested the wrong logic but integration test was testing the correct one).
Edit:
I reverted filtering logic. Only changes now are test fixes.