### PR TITLE
ACS-6874: Adding primary path/ancestor node filtering in live ingester.

### DIFF
--- a/bulk-ingester/src/main/java/org/alfresco/hxi_connector/bulk_ingester/repository/filter/TypeFilterApplier.java
+++ b/bulk-ingester/src/main/java/org/alfresco/hxi_connector/bulk_ingester/repository/filter/TypeFilterApplier.java
@@ -34,7 +34,7 @@ import org.springframework.stereotype.Component;
 
 import org.alfresco.elasticsearch.db.connector.model.AlfrescoNode;
 import org.alfresco.hxi_connector.bulk_ingester.processor.mapper.NamespacePrefixMapper;
-import org.alfresco.hxi_connector.common.repository.filter.TypeFilter;
+import org.alfresco.hxi_connector.common.repository.filter.FieldFilter;
 
 @Component
 @RequiredArgsConstructor
@@ -50,6 +50,6 @@ public class TypeFilterApplier implements AlfrescoNodeFilterApplier
         final List<String> allowed = filterConfig.type().allow();
         final List<String> denied = filterConfig.type().deny();
         log.atDebug().log("Applying type filters on Alfresco node of id: {}", alfrescoNode.getId());
-        return TypeFilter.filter(nodeType, allowed, denied);
+        return FieldFilter.filter(nodeType, allowed, denied);
     }
 }

--- a/common/src/main/java/org/alfresco/hxi_connector/common/repository/filter/CollectionFilter.java
+++ b/common/src/main/java/org/alfresco/hxi_connector/common/repository/filter/CollectionFilter.java
@@ -25,7 +25,7 @@
  */
 package org.alfresco.hxi_connector.common.repository.filter;
 
-import java.util.List;
+import java.util.Collection;
 import jakarta.validation.constraints.NotNull;
 
 import lombok.AccessLevel;
@@ -34,24 +34,25 @@ import lombok.extern.slf4j.Slf4j;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Slf4j
-public final class TypeFilter
+public final class CollectionFilter
 {
-    public static boolean filter(String nodeType, List<String> allowed, List<String> denied)
+
+    public static boolean filter(Collection<String> fields, Collection<String> allowed, Collection<String> denied)
     {
-        final boolean allow = isAllowed(nodeType, allowed);
-        final boolean deny = isDenied(nodeType, denied);
+        final boolean allow = isAllowed(fields, allowed);
+        final boolean deny = isDenied(fields, denied);
         boolean result = allow && !deny;
-        log.atDebug().log("Node type: {}. Allowed types: {}. Denied types: {}. Is allowed: {}", nodeType, allowed, denied, result);
+        log.atDebug().log("Node fields collection: {}. Allowed values: {}. Denied values: {}. Is allowed: {}", fields, allowed, denied, result);
         return result;
     }
 
-    private static boolean isAllowed(@NotNull String nodeType, @NotNull List<String> allowed)
+    private static boolean isAllowed(@NotNull Collection<String> fields, @NotNull Collection<String> allowed)
     {
-        return allowed.isEmpty() || allowed.contains(nodeType);
+        return allowed.isEmpty() || allowed.stream().anyMatch(fields::contains);
     }
 
-    private static boolean isDenied(@NotNull String nodeType, @NotNull List<String> denied)
+    private static boolean isDenied(@NotNull Collection<String> fields, @NotNull Collection<String> denied)
     {
-        return denied.contains(nodeType);
+        return denied.stream().anyMatch(fields::contains);
     }
 }

--- a/common/src/main/java/org/alfresco/hxi_connector/common/repository/filter/FieldFilter.java
+++ b/common/src/main/java/org/alfresco/hxi_connector/common/repository/filter/FieldFilter.java
@@ -26,7 +26,6 @@
 package org.alfresco.hxi_connector.common.repository.filter;
 
 import java.util.List;
-import java.util.Set;
 import jakarta.validation.constraints.NotNull;
 
 import lombok.AccessLevel;
@@ -35,25 +34,24 @@ import lombok.extern.slf4j.Slf4j;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Slf4j
-public final class AspectFilter
+public final class FieldFilter
 {
-
-    public static boolean filter(Set<String> aspectNames, List<String> allowed, List<String> denied)
+    public static boolean filter(String nodeField, List<String> allowed, List<String> denied)
     {
-        final boolean allow = isAllowed(aspectNames, allowed);
-        final boolean deny = isDenied(aspectNames, denied);
+        final boolean allow = isAllowed(nodeField, allowed);
+        final boolean deny = isDenied(nodeField, denied);
         boolean result = allow && !deny;
-        log.atDebug().log("Node aspects: {}. Allowed aspects: {}. Denied aspects: {}. Is allowed: {}", aspectNames, allowed, denied, result);
+        log.atDebug().log("Node field: {}. Allowed values: {}. Denied values: {}. Is allowed: {}", nodeField, allowed, denied, result);
         return result;
     }
 
-    private static boolean isAllowed(@NotNull Set<String> aspectNames, @NotNull List<String> allowed)
+    private static boolean isAllowed(@NotNull String nodeField, @NotNull List<String> allowed)
     {
-        return allowed.isEmpty() || allowed.stream().anyMatch(aspectNames::contains);
+        return allowed.isEmpty() || allowed.contains(nodeField);
     }
 
-    private static boolean isDenied(@NotNull Set<String> aspectNames, @NotNull List<String> denied)
+    private static boolean isDenied(@NotNull String nodeField, @NotNull List<String> denied)
     {
-        return denied.stream().anyMatch(aspectNames::contains);
+        return denied.contains(nodeField);
     }
 }

--- a/common/src/test/java/org/alfresco/hxi_connector/common/repository/filter/CollectionFilterTest.java
+++ b/common/src/test/java/org/alfresco/hxi_connector/common/repository/filter/CollectionFilterTest.java
@@ -74,9 +74,9 @@ class CollectionFilterTest
 
     @ParameterizedTest
     @MethodSource("provideAncestorParameters")
-    void testAncestorFiltering(boolean expected, List<String> aspects, List<String> allowed, List<String> denied)
+    void testAncestorFiltering(boolean expected, List<String> ancestors, List<String> allowed, List<String> denied)
     {
-        boolean result = CollectionFilter.filter(aspects, allowed, denied);
+        boolean result = CollectionFilter.filter(ancestors, allowed, denied);
         if (expected)
         {
             assertTrue(result);

--- a/common/src/test/java/org/alfresco/hxi_connector/common/repository/filter/CollectionFilterTest.java
+++ b/common/src/test/java/org/alfresco/hxi_connector/common/repository/filter/CollectionFilterTest.java
@@ -62,14 +62,7 @@ class CollectionFilterTest
     void testAspectFiltering(boolean expected, Set<String> aspects, List<String> allowed, List<String> denied)
     {
         boolean result = CollectionFilter.filter(aspects, allowed, denied);
-        if (expected)
-        {
-            assertTrue(result);
-        }
-        else
-        {
-            assertFalse(result);
-        }
+        assertEquals(expected, result, "Unexpected result from filter");
     }
 
     @ParameterizedTest
@@ -77,14 +70,7 @@ class CollectionFilterTest
     void testAncestorFiltering(boolean expected, List<String> ancestors, List<String> allowed, List<String> denied)
     {
         boolean result = CollectionFilter.filter(ancestors, allowed, denied);
-        if (expected)
-        {
-            assertTrue(result);
-        }
-        else
-        {
-            assertFalse(result);
-        }
+        assertEquals(expected, result, "Unexpected result from filter");
     }
 
     private static Stream<Arguments> provideAspectParameters()

--- a/common/src/test/java/org/alfresco/hxi_connector/common/repository/filter/FieldFilterTest.java
+++ b/common/src/test/java/org/alfresco/hxi_connector/common/repository/filter/FieldFilterTest.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-class TypeFilterTest
+class FieldFilterTest
 {
 
     private static final String ALLOW_NODE = "Allow node when: ";
@@ -47,14 +47,14 @@ class TypeFilterTest
     private static final String CM_FOLDER = "cm:folder";
     private static final String CM_CONTENT = "cm:content";
     private static final String CM_SPECIAL_FOLDER = "cm:special-folder";
-    private static final String TYPE = "Node type: ";
+    private static final String FIELD = "Field value: ";
 
     @ParameterizedTest
-    @MethodSource("provideParameters")
-    void testAspectFiltering(boolean expected, String nodeType, List<String> allowed, List<String> denied)
+    @MethodSource("provideTypeParameters")
+    void testTypeFiltering(boolean expected, String nodeType, List<String> allowed, List<String> denied)
     {
         // when
-        boolean result = TypeFilter.filter(nodeType, allowed, denied);
+        boolean result = FieldFilter.filter(nodeType, allowed, denied);
         // then
         if (expected)
         {
@@ -66,7 +66,7 @@ class TypeFilterTest
         }
     }
 
-    private static Stream<Arguments> provideParameters()
+    private static Stream<Arguments> provideTypeParameters()
     {
         return Stream.of(
                 composeArguments(true, CM_FOLDER, emptyList(), emptyList()),
@@ -79,8 +79,7 @@ class TypeFilterTest
 
     private static Arguments composeArguments(boolean allowNode, String nodeType, List<String> allowed, List<String> denied)
     {
-
-        return Arguments.of(named(allowNode ? ALLOW_NODE : DENY_NODE, allowNode), named(TYPE + nodeType, nodeType),
+        return Arguments.of(named(allowNode ? ALLOW_NODE : DENY_NODE, allowNode), named(FIELD + nodeType, nodeType),
                 named(ALLOWED + allowed, allowed), named(DENIED + denied, denied));
     }
 

--- a/common/src/test/java/org/alfresco/hxi_connector/common/repository/filter/FieldFilterTest.java
+++ b/common/src/test/java/org/alfresco/hxi_connector/common/repository/filter/FieldFilterTest.java
@@ -56,14 +56,7 @@ class FieldFilterTest
         // when
         boolean result = FieldFilter.filter(nodeType, allowed, denied);
         // then
-        if (expected)
-        {
-            assertTrue(result);
-        }
-        else
-        {
-            assertFalse(result);
-        }
+        assertEquals(expected, result, "Unexpected result from filter");
     }
 
     private static Stream<Arguments> provideTypeParameters()

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/RequestFiltersIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/RequestFiltersIntegrationTest.java
@@ -37,13 +37,15 @@ import org.alfresco.hxi_connector.live_ingester.util.E2ETestBase;
         "alfresco.filter.aspect.allow[0]=cm:versionable", "alfresco.filter.aspect.allow[1]=cm:auditable",
         "alfresco.filter.type.deny[0]=cm:folder",
         "alfresco.filter.type.allow[0]=cm:content",
+        "alfresco.filter.path.allow[0]=5f355d16-f824-4173-bf4b-b1ec37ef5549", "alfresco.filter.path.allow[1]=93f7edf5-e4d8-4749-9b4c-e45097e2e19d",
+        "alfresco.filter.path.deny[0]=93f7edf5-e4d8-4749-9b4c-e45097e2e19e",
         "logging.level.org.alfresco=DEBUG"})
 @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 public class RequestFiltersIntegrationTest extends E2ETestBase
 {
 
     @Test
-    void testCreateRequestWithAspectInAllowedFilterAndTypeInAllowedFilter()
+    void testCreateRequestWithAspectInAllowedFilterAndTypeInAllowedFilterAndAncestorInAllowedFilter()
     {
         // given
         containerSupport.prepareHxInsightToReturnSuccess();
@@ -128,7 +130,7 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
     }
 
     @Test
-    void testCreateRequestWithAspectInDeniedFilterAndTypeInAllowedFilter()
+    void testCreateRequestWithAspectInDeniedFilterAndTypeInAllowedFilterAndAncestorInAllowedFilter()
     {
         // given
         String repoEvent = """
@@ -185,7 +187,7 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
     }
 
     @Test
-    void testCreateRequestWithAtLeastOneAspectPresentInAllowedFilterAndTypeInAllowedFilter()
+    void testCreateRequestWithAtLeastOneAspectPresentInAllowedFilterAndTypeInAllowedFilterAndAncestorInAllowedFilter()
     {
         // given
         containerSupport.prepareHxInsightToReturnSuccess();
@@ -259,7 +261,64 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
     }
 
     @Test
-    void testUpdateRequestWithAspectInAllowedFilterAndTypeInAllowedFilter()
+    void testCreateRequestWithAtLeastOneAspectPresentInAllowedFilterAndTypeInAllowedFilterAndAncestorInDeniedFilter()
+    {
+        // given
+        String repoEvent = """
+                {
+                  "specversion": "1.0",
+                  "type": "org.alfresco.event.node.Created",
+                  "id": "368818d9-dddd-4b8b-8eab-e050253d7f03",
+                  "source": "/08d9b620-48de-4247-8f33-360988d3b19b",
+                  "time": "2021-01-21T11:14:16.42372Z",
+                  "dataschema": "https://api.alfresco.com/schema/event/repo/v1/nodeCreated",
+                  "datacontenttype": "application/json",
+                  "data": {
+                    "eventGroupId": "4004ca99-9d2a-400d-9d80-8f840e223503",
+                    "resource": {
+                      "@type": "NodeResource",
+                      "id": "d71dd823-82c7-477c-8490-04cb0e826e03",
+                      "primaryHierarchy": [ "5f355d16-f824-4173-bf4b-b1ec37ef5549", "93f7edf5-e4d8-4749-9b4c-e45097e2e19e" ],
+                      "name": "purchase-order-scan.pdf",
+                      "nodeType": "cm:content",
+                      "createdByUser": {
+                        "id": "admin",
+                        "displayName": "Administrator"
+                      },
+                      "createdAt": "2024-03-02T11:14:15.695Z",
+                      "modifiedByUser": {
+                        "id": "admin",
+                        "displayName": "Administrator"
+                      },
+                      "modifiedAt": "2024-03-06T11:14:15.695Z",
+                      "content": {
+                        "mimeType": "application/pdf",
+                        "sizeInBytes": 531152,
+                        "encoding": "UTF-8"
+                      },
+                      "properties": {
+                        "cm:autoVersion": true,
+                        "cm:versionType": "MAJOR",
+                        "cm:taggable": null
+                      },
+                      "aspectNames": [ "cm:versionable", "cm:auditable", "cm:classifiable" ],
+                      "isFolder": false,
+                      "isFile": true
+                    },
+                    "resourceReaderAuthorities": [ "GROUP_EVERYONE" ],
+                    "resourceDeniedAuthorities": []
+                  }
+                }""";
+
+        // when
+        containerSupport.raiseRepoEvent(repoEvent);
+
+        // then
+        containerSupport.expectNoHxIngestMessagesReceived();
+    }
+
+    @Test
+    void testUpdateRequestWithAspectInAllowedFilterAndTypeInAllowedFilterAndAncestorInAllowedFilter()
     {
         // given
         containerSupport.prepareHxInsightToReturnSuccess();
@@ -278,6 +337,7 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                     "resource": {
                       "@type": "NodeResource",
                       "id": "d71dd823-82c7-477c-8490-04cb0e826e04",
+                      "primaryHierarchy": [ "5f355d16-f824-4173-bf4b-b1ec37ef5549", "93f7edf5-e4d8-4749-9b4c-e45097e2e19d" ],
                       "name": "purchase-order-scan.pdf",
                       "nodeType": "cm:content",
                       "createdByUser": {
@@ -343,7 +403,7 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
     }
 
     @Test
-    void testUpdateRequestWithAspectInDeniedFilterAndTypeInAllowedFilter()
+    void testUpdateRequestWithAspectInDeniedFilterAndTypeInAllowedFilterAndAncestorInAllowedFilter()
     {
         // given
         String repoEvent = """
@@ -413,7 +473,7 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
     }
 
     @Test
-    void testUpdateRequestWithAtLeastOneAspectInAllowedFilterAndTypeInAllowedFilter()
+    void testUpdateRequestWithAtLeastOneAspectInAllowedFilterAndTypeInAllowedFilterAndAncestorInAllowedFilter()
     {
         // given
         containerSupport.prepareHxInsightToReturnSuccess();
@@ -432,6 +492,7 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                     "resource": {
                       "@type": "NodeResource",
                       "id": "d71dd823-82c7-477c-8490-04cb0e826e06",
+                      "primaryHierarchy": [ "5f355d16-f824-4173-bf4b-b1ec37ef5549", "93f7edf5-e4d8-4749-9b4c-e45097e2e19d" ],
                       "name": "purchase-order-scan.pdf",
                       "nodeType": "cm:content",
                       "createdByUser": {
@@ -497,7 +558,79 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
     }
 
     @Test
-    void testCreateRequestWithEmptyAspectCollectionAndTypeInAllowedFilter()
+    void testUpdateRequestWithAtLeastOneAspectInAllowedFilterAndTypeInAllowedFilterAndAncestorInDeniedFilter()
+    {
+        // given
+        String repoEvent = """
+                {
+                  "specversion": "1.0",
+                  "type": "org.alfresco.event.node.Updated",
+                  "id": "ae5dac3c-25d0-438d-b148-2084d1ab0506",
+                  "source": "/08d9b620-48de-4247-8f33-360988d3b19b",
+                  "time": "2021-01-26T10:29:42.99524Z",
+                  "dataschema": "https://api.alfresco.com/schema/event/repo/v1/nodeUpdated",
+                  "datacontenttype": "application/json",
+                  "data": {
+                    "eventGroupId": "b5b1ebfe-45fc-4f86-b71b-421996482806",
+                    "resource": {
+                      "@type": "NodeResource",
+                      "id": "d71dd823-82c7-477c-8490-04cb0e826e06",
+                      "primaryHierarchy": [ "5f355d16-f824-4173-bf4b-b1ec37ef5549", "93f7edf5-e4d8-4749-9b4c-e45097e2e19e" ],
+                      "name": "purchase-order-scan.pdf",
+                      "nodeType": "cm:content",
+                      "createdByUser": {
+                        "id": "admin",
+                        "displayName": "Administrator"
+                      },
+                      "createdAt": "2024-03-02T11:14:15.695Z",
+                      "modifiedByUser": {
+                        "id": "abeecher",
+                        "displayName": "Alice Beecher"
+                      },
+                      "modifiedAt": "2024-03-06T10:29:42.529Z",
+                      "content": {
+                        "mimeType": "application/pdf",
+                        "sizeInBytes": 531152,
+                        "encoding": "UTF-8"
+                      },
+                      "properties": {
+                        "cm:title": "Purchase Order",
+                        "cm:versionType": null,
+                        "cm:versionLabel": "1.0",
+                        "cm:taggable": null
+                      },
+                      "aspectNames": [ "cm:versionable", "cm:author", "cm:titled", "cm:classifiable" ],
+                      "isFolder": false,
+                      "isFile": true
+                    },
+                    "resourceBefore": {
+                      "@type": "NodeResource",
+                      "modifiedAt": "2024-03-02T11:14:25.223Z",
+                      "modifiedByUser": {
+                        "id": "admin",
+                        "displayName": "Administrator"
+                      },
+                      "properties": {
+                        "cm:title": null,
+                        "cm:versionType": "MAJOR",
+                        "cm:versionLabel": "1.0",
+                        "cm:taggable": null,
+                        "cm:description": "Old Description"
+                      },
+                      "aspectNames": [ "cm:versionable" ]
+                    }
+                  }
+                }""";
+
+        // when
+        containerSupport.raiseRepoEvent(repoEvent);
+
+        // then
+        containerSupport.expectNoHxIngestMessagesReceived();
+    }
+
+    @Test
+    void testCreateRequestWithEmptyAspectCollectionAndTypeInAllowedFilterAndAncestorInAllowedFilter()
     {
         // given
         String repoEvent = """
@@ -554,7 +687,7 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
     }
 
     @Test
-    void testCreateRequestWithNoAspectsInEventAndTypeInAllowedFilter()
+    void testCreateRequestWithNoAspectsInEventAndTypeInAllowedFilterAndAncestorInAllowedFilter()
     {
         // given
         String repoEvent = """
@@ -610,7 +743,7 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
     }
 
     @Test
-    void testCreateRequestWithAspectInAllowedFilterAndTypeInDeniedFilter()
+    void testCreateRequestWithAspectInAllowedFilterAndTypeInDeniedFilterAndAncestorInAllowedFilter()
     {
         // given
         String repoEvent = """
@@ -666,7 +799,7 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
     }
 
     @Test
-    void testUpdateRequestWithAspectInAllowedFilterAndTypeInDeniedFilter()
+    void testUpdateRequestWithAspectInAllowedFilterAndTypeInDeniedFilterAndAncestorInAllowedFilter()
     {
         // given
         String repoEvent = """

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/RequestFiltersIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/RequestFiltersIntegrationTest.java
@@ -38,7 +38,7 @@ import org.alfresco.hxi_connector.live_ingester.util.E2ETestBase;
         "alfresco.filter.type.deny[0]=cm:folder",
         "alfresco.filter.type.allow[0]=cm:content",
         "alfresco.filter.path.allow[0]=5f355d16-f824-4173-bf4b-b1ec37ef5549", "alfresco.filter.path.allow[1]=93f7edf5-e4d8-4749-9b4c-e45097e2e19d",
-        "alfresco.filter.path.deny[0]=93f7edf5-e4d8-4749-9b4c-e45097e2e19e",
+        "alfresco.filter.path.deny[0]=11111111-1111-1111-1111-111111111111",
         "logging.level.org.alfresco=DEBUG"})
 @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 public class RequestFiltersIntegrationTest extends E2ETestBase
@@ -278,7 +278,7 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                     "resource": {
                       "@type": "NodeResource",
                       "id": "d71dd823-82c7-477c-8490-04cb0e826e03",
-                      "primaryHierarchy": [ "5f355d16-f824-4173-bf4b-b1ec37ef5549", "93f7edf5-e4d8-4749-9b4c-e45097e2e19e" ],
+                      "primaryHierarchy": [ "5f355d16-f824-4173-bf4b-b1ec37ef5549", "11111111-1111-1111-1111-111111111111" ],
                       "name": "purchase-order-scan.pdf",
                       "nodeType": "cm:content",
                       "createdByUser": {
@@ -575,7 +575,7 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                     "resource": {
                       "@type": "NodeResource",
                       "id": "d71dd823-82c7-477c-8490-04cb0e826e06",
-                      "primaryHierarchy": [ "5f355d16-f824-4173-bf4b-b1ec37ef5549", "93f7edf5-e4d8-4749-9b4c-e45097e2e19e" ],
+                      "primaryHierarchy": [ "5f355d16-f824-4173-bf4b-b1ec37ef5549", "11111111-1111-1111-1111-111111111111" ],
                       "name": "purchase-order-scan.pdf",
                       "nodeType": "cm:content",
                       "createdByUser": {

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/config/properties/Filter.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/config/properties/Filter.java
@@ -29,11 +29,14 @@ package org.alfresco.hxi_connector.live_ingester.adapters.config.properties;
 import java.util.List;
 import jakarta.validation.constraints.NotNull;
 
-public record Filter(@NotNull Aspect aspect, @NotNull Type type)
+public record Filter(@NotNull Aspect aspect, @NotNull Type type, @NotNull Path path)
 {
     public record Aspect(@NotNull List<String> allow, @NotNull List<String> deny)
     {}
 
     public record Type(@NotNull List<String> allow, @NotNull List<String> deny)
+    {}
+
+    public record Path(@NotNull List<String> allow, @NotNull List<String> deny)
     {}
 }

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/filter/AspectFilterApplier.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/filter/AspectFilterApplier.java
@@ -34,7 +34,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.SetUtils;
 import org.springframework.stereotype.Component;
 
-import org.alfresco.hxi_connector.common.repository.filter.AspectFilter;
+import org.alfresco.hxi_connector.common.repository.filter.CollectionFilter;
 import org.alfresco.hxi_connector.live_ingester.adapters.config.properties.Filter;
 import org.alfresco.repo.event.v1.model.DataAttributes;
 import org.alfresco.repo.event.v1.model.NodeResource;
@@ -52,7 +52,7 @@ public class AspectFilterApplier implements RepoEventFilterApplier
         final List<String> allowed = filter.aspect().allow();
         final List<String> denied = filter.aspect().deny();
         log.atDebug().log("Applying aspect filters on repo event of id: {}, node id: {}", repoEvent.getId(), repoEvent.getData().getResource().getId());
-        return AspectFilter.filter(aspectNames, allowed, denied);
+        return CollectionFilter.filter(aspectNames, allowed, denied);
     }
 
 }

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/filter/TypeFilterApplier.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/filter/TypeFilterApplier.java
@@ -32,7 +32,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
-import org.alfresco.hxi_connector.common.repository.filter.TypeFilter;
+import org.alfresco.hxi_connector.common.repository.filter.FieldFilter;
 import org.alfresco.hxi_connector.live_ingester.adapters.config.properties.Filter;
 import org.alfresco.repo.event.v1.model.DataAttributes;
 import org.alfresco.repo.event.v1.model.NodeResource;
@@ -50,6 +50,6 @@ public class TypeFilterApplier implements RepoEventFilterApplier
         final List<String> allowed = filter.type().allow();
         final List<String> denied = filter.type().deny();
         log.atDebug().log("Applying type filters on repo event of id: {}, node id: {}", repoEvent.getId(), repoEvent.getData().getResource().getId());
-        return TypeFilter.filter(nodeType, allowed, denied);
+        return FieldFilter.filter(nodeType, allowed, denied);
     }
 }

--- a/live-ingester/src/main/resources/application.yml
+++ b/live-ingester/src/main/resources/application.yml
@@ -41,6 +41,9 @@ alfresco:
     type:
       allow:
       deny:
+    path:
+      allow:
+      deny:
 hyland-experience:
   insight:
     base-url: http://localhost:8001

--- a/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/filter/AncestorFilterApplierTest.java
+++ b/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/filter/AncestorFilterApplierTest.java
@@ -1,0 +1,100 @@
+/*-
+ * #%L
+ * Alfresco HX Insight Connector
+ * %%
+ * Copyright (C) 2023 - 2024 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.filter;
+
+import static java.util.Collections.emptyList;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.alfresco.hxi_connector.live_ingester.adapters.config.properties.Filter;
+import org.alfresco.repo.event.v1.model.DataAttributes;
+import org.alfresco.repo.event.v1.model.NodeResource;
+import org.alfresco.repo.event.v1.model.RepoEvent;
+
+@ExtendWith(MockitoExtension.class)
+class AncestorFilterApplierTest
+{
+    private static final String ANCESTOR = "parent-node-id";
+    @Mock
+    private RepoEvent<DataAttributes<NodeResource>> mockRepoEvent;
+    @Mock
+    private DataAttributes<NodeResource> mockData;
+    @Mock
+    private NodeResource mockResource;
+    @Mock
+    private Filter mockFilter;
+    @Mock
+    private Filter.Path mockPath;
+
+    @InjectMocks
+    private AncestorFilterApplier objectUnderTest;
+
+    @BeforeEach
+    void mockBasicData()
+    {
+        given(mockRepoEvent.getData()).willReturn(mockData);
+        given(mockData.getResource()).willReturn(mockResource);
+        given(mockFilter.path()).willReturn(mockPath);
+    }
+
+    @Test
+    void shouldNotFilterOutNullPrimaryHierarchyWhenEmptyAllowedAndEmptyDenied()
+    {
+        given(mockResource.getPrimaryHierarchy()).willReturn(null);
+        given(mockPath.allow()).willReturn(emptyList());
+        given(mockPath.deny()).willReturn(emptyList());
+
+        // when
+        boolean result = objectUnderTest.applyFilter(mockRepoEvent, mockFilter);
+
+        // then
+        assertTrue(result);
+    }
+
+    @Test
+    void shouldFilterOutWhenPrimaryHierarchyNullAndNonEmptyAllowedAndEmptyDenied()
+    {
+        given(mockResource.getPrimaryHierarchy()).willReturn(null);
+        given(mockPath.allow()).willReturn(List.of(ANCESTOR));
+        given(mockPath.deny()).willReturn(emptyList());
+
+        // when
+        boolean result = objectUnderTest.applyFilter(mockRepoEvent, mockFilter);
+
+        // then
+        assertFalse(result);
+    }
+}


### PR DESCRIPTION
I assumed that primary path/ancestors will be under same filtering rules as aspects, thus, I've made small generalization for filter utility classes.