### PR TITLE
ACS-6951 Map filtered out update event to create/delete when needed

### DIFF
--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/RequestFiltersIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/RequestFiltersIntegrationTest.java
@@ -1287,4 +1287,75 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                 ]""";
         containerSupport.expectHxIngestMessageReceived(expectedBody);
     }
+
+    @Test
+    void testUpdateRequestWhenSingleFilterDeniedNodeBeforeAndAnotherSingleFilterDeniesCurrentNode()
+    {
+        // given
+        String repoEvent = """
+                {
+                  "specversion": "1.0",
+                  "type": "org.alfresco.event.node.Updated",
+                  "id": "ae5dac3c-25d0-438d-b148-2084d1ab0517",
+                  "primaryHierarchy": [ "11111111-1111-1111-1111-111111111111", "5f355d16-f824-4173-bf4b-b1ec37ef5549", "93f7edf5-e4d8-4749-9b4c-e45097e2e19d" ],
+                  "source": "/08d9b620-48de-4247-8f33-360988d3b19b",
+                  "time": "2021-01-26T10:29:42.99524Z",
+                  "dataschema": "https://api.alfresco.com/schema/event/repo/v1/nodeUpdated",
+                  "datacontenttype": "application/json",
+                  "data": {
+                    "eventGroupId": "b5b1ebfe-45fc-4f86-b71b-421996482817",
+                    "resource": {
+                      "@type": "NodeResource",
+                      "id": "d71dd823-82c7-477c-8490-04cb0e826e17",
+                      "name": "purchase-order-scan.pdf",
+                      "nodeType": "cm:folder",
+                      "createdByUser": {
+                        "id": "admin",
+                        "displayName": "Administrator"
+                      },
+                      "createdAt": "2024-03-02T11:14:15.695Z",
+                      "modifiedByUser": {
+                        "id": "abeecher",
+                        "displayName": "Alice Beecher"
+                      },
+                      "modifiedAt": "2024-03-06T10:29:42.529Z",
+                      "content": {
+                        "mimeType": "application/pdf",
+                        "sizeInBytes": 531152,
+                        "encoding": "UTF-8"
+                      },
+                      "properties": {
+                        "cm:title": "Purchase Order",
+                        "cm:versionType": null,
+                        "cm:versionLabel": "1.0",
+                        "cm:taggable": null
+                      },
+                      "aspectNames": [ "cm:versionable", "cm:author", "cm:titled" ],
+                      "isFolder": false,
+                      "isFile": true
+                    },
+                    "resourceBefore": {
+                      "@type": "NodeResource",
+                      "modifiedAt": "2024-03-02T11:14:25.223Z",
+                      "modifiedByUser": {
+                        "id": "admin",
+                        "displayName": "Administrator"
+                      },
+                      "properties": {
+                        "cm:title": null,
+                        "cm:versionType": "MAJOR",
+                        "cm:versionLabel": "1.0",
+                        "cm:taggable": null,
+                        "cm:description": "Old Description"
+                      },
+                      "aspectNames": [ "cm:versionable", "cm:thumbnailModification", "sc:secured" ]
+                    }
+                  }
+                }""";
+        // when
+        containerSupport.raiseRepoEvent(repoEvent);
+
+        // then
+        containerSupport.expectNoHxIngestMessagesReceived();
+    }
 }

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/RequestFiltersIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/RequestFiltersIntegrationTest.java
@@ -290,16 +290,16 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                 {
                   "specversion": "1.0",
                   "type": "org.alfresco.event.node.Created",
-                  "id": "368818d9-dddd-4b8b-8eab-e050253d7f03",
+                  "id": "368818d9-dddd-4b8b-8eab-e050253d7f04",
                   "source": "/08d9b620-48de-4247-8f33-360988d3b19b",
                   "time": "2021-01-21T11:14:16.42372Z",
                   "dataschema": "https://api.alfresco.com/schema/event/repo/v1/nodeCreated",
                   "datacontenttype": "application/json",
                   "data": {
-                    "eventGroupId": "4004ca99-9d2a-400d-9d80-8f840e223503",
+                    "eventGroupId": "4004ca99-9d2a-400d-9d80-8f840e223504",
                     "resource": {
                       "@type": "NodeResource",
-                      "id": "d71dd823-82c7-477c-8490-04cb0e826e03",
+                      "id": "d71dd823-82c7-477c-8490-04cb0e826e04",
                       "primaryHierarchy": [ "5f355d16-f824-4173-bf4b-b1ec37ef5549", "11111111-1111-1111-1111-111111111111" ],
                       "name": "purchase-order-scan.pdf",
                       "nodeType": "cm:content",
@@ -349,16 +349,16 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                 {
                   "specversion": "1.0",
                   "type": "org.alfresco.event.node.Updated",
-                  "id": "ae5dac3c-25d0-438d-b148-2084d1ab0504",
+                  "id": "ae5dac3c-25d0-438d-b148-2084d1ab0505",
                   "source": "/08d9b620-48de-4247-8f33-360988d3b19b",
                   "time": "2021-01-26T10:29:42.99524Z",
                   "dataschema": "https://api.alfresco.com/schema/event/repo/v1/nodeUpdated",
                   "datacontenttype": "application/json",
                   "data": {
-                    "eventGroupId": "b5b1ebfe-45fc-4f86-b71b-421996482804",
+                    "eventGroupId": "b5b1ebfe-45fc-4f86-b71b-421996482805",
                     "resource": {
                       "@type": "NodeResource",
-                      "id": "d71dd823-82c7-477c-8490-04cb0e826e04",
+                      "id": "d71dd823-82c7-477c-8490-04cb0e826e05",
                       "primaryHierarchy": [ "5f355d16-f824-4173-bf4b-b1ec37ef5549", "93f7edf5-e4d8-4749-9b4c-e45097e2e19d" ],
                       "name": "purchase-order-scan.pdf",
                       "nodeType": "cm:content",
@@ -413,7 +413,7 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
         String expectedBody = """
                 [
                   {
-                    "objectId": "d71dd823-82c7-477c-8490-04cb0e826e04",
+                    "objectId": "d71dd823-82c7-477c-8490-04cb0e826e05",
                     "eventType": "update",
                     "properties": {
                       "cm:title": {"value": "Purchase Order"},
@@ -434,16 +434,16 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                 {
                   "specversion": "1.0",
                   "type": "org.alfresco.event.node.Updated",
-                  "id": "ae5dac3c-25d0-438d-b148-2084d1ab0505",
+                  "id": "ae5dac3c-25d0-438d-b148-2084d1ab0506",
                   "source": "/08d9b620-48de-4247-8f33-360988d3b19b",
                   "time": "2021-01-26T10:29:42.99524Z",
                   "dataschema": "https://api.alfresco.com/schema/event/repo/v1/nodeUpdated",
                   "datacontenttype": "application/json",
                   "data": {
-                    "eventGroupId": "b5b1ebfe-45fc-4f86-b71b-421996482805",
+                    "eventGroupId": "b5b1ebfe-45fc-4f86-b71b-421996482806",
                     "resource": {
                       "@type": "NodeResource",
-                      "id": "d71dd823-82c7-477c-8490-04cb0e826e05",
+                      "id": "d71dd823-82c7-477c-8490-04cb0e826e06",
                       "name": "purchase-order-scan.pdf",
                       "nodeType": "cm:content",
                       "createdByUser": {
@@ -506,16 +506,16 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                 {
                   "specversion": "1.0",
                   "type": "org.alfresco.event.node.Updated",
-                  "id": "ae5dac3c-25d0-438d-b148-2084d1ab0506",
+                  "id": "ae5dac3c-25d0-438d-b148-2084d1ab0507",
                   "source": "/08d9b620-48de-4247-8f33-360988d3b19b",
                   "time": "2021-01-26T10:29:42.99524Z",
                   "dataschema": "https://api.alfresco.com/schema/event/repo/v1/nodeUpdated",
                   "datacontenttype": "application/json",
                   "data": {
-                    "eventGroupId": "b5b1ebfe-45fc-4f86-b71b-421996482806",
+                    "eventGroupId": "b5b1ebfe-45fc-4f86-b71b-421996482807",
                     "resource": {
                       "@type": "NodeResource",
-                      "id": "d71dd823-82c7-477c-8490-04cb0e826e06",
+                      "id": "d71dd823-82c7-477c-8490-04cb0e826e07",
                       "primaryHierarchy": [ "5f355d16-f824-4173-bf4b-b1ec37ef5549", "93f7edf5-e4d8-4749-9b4c-e45097e2e19d" ],
                       "name": "purchase-order-scan.pdf",
                       "nodeType": "cm:content",
@@ -570,7 +570,7 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
         String expectedBody = """
                 [
                   {
-                    "objectId": "d71dd823-82c7-477c-8490-04cb0e826e06",
+                    "objectId": "d71dd823-82c7-477c-8490-04cb0e826e07",
                     "eventType": "update",
                     "properties": {
                       "cm:title": {"value": "Purchase Order"},
@@ -591,16 +591,16 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                 {
                   "specversion": "1.0",
                   "type": "org.alfresco.event.node.Updated",
-                  "id": "ae5dac3c-25d0-438d-b148-2084d1ab0506",
+                  "id": "ae5dac3c-25d0-438d-b148-2084d1ab0508",
                   "source": "/08d9b620-48de-4247-8f33-360988d3b19b",
                   "time": "2021-01-26T10:29:42.99524Z",
                   "dataschema": "https://api.alfresco.com/schema/event/repo/v1/nodeUpdated",
                   "datacontenttype": "application/json",
                   "data": {
-                    "eventGroupId": "b5b1ebfe-45fc-4f86-b71b-421996482806",
+                    "eventGroupId": "b5b1ebfe-45fc-4f86-b71b-421996482808",
                     "resource": {
                       "@type": "NodeResource",
-                      "id": "d71dd823-82c7-477c-8490-04cb0e826e06",
+                      "id": "d71dd823-82c7-477c-8490-04cb0e826e08",
                       "primaryHierarchy": [ "5f355d16-f824-4173-bf4b-b1ec37ef5549", "11111111-1111-1111-1111-111111111111" ],
                       "name": "purchase-order-scan.pdf",
                       "nodeType": "cm:content",
@@ -663,16 +663,16 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                 {
                   "specversion": "1.0",
                   "type": "org.alfresco.event.node.Created",
-                  "id": "368818d9-dddd-4b8b-8eab-e050253d7f07",
+                  "id": "368818d9-dddd-4b8b-8eab-e050253d7f09",
                   "source": "/08d9b620-48de-4247-8f33-360988d3b19b",
                   "time": "2021-01-21T11:14:16.42372Z",
                   "dataschema": "https://api.alfresco.com/schema/event/repo/v1/nodeCreated",
                   "datacontenttype": "application/json",
                   "data": {
-                    "eventGroupId": "4004ca99-9d2a-400d-9d80-8f840e223507",
+                    "eventGroupId": "4004ca99-9d2a-400d-9d80-8f840e223509",
                     "resource": {
                       "@type": "NodeResource",
-                      "id": "d71dd823-82c7-477c-8490-04cb0e826e07",
+                      "id": "d71dd823-82c7-477c-8490-04cb0e826e09",
                       "primaryHierarchy": [ "5f355d16-f824-4173-bf4b-b1ec37ef5549", "93f7edf5-e4d8-4749-9b4c-e45097e2e19d" ],
                       "name": "purchase-order-scan.pdf",
                       "nodeType": "cm:content",
@@ -720,16 +720,16 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                 {
                   "specversion": "1.0",
                   "type": "org.alfresco.event.node.Created",
-                  "id": "368818d9-dddd-4b8b-8eab-e050253d7f08",
+                  "id": "368818d9-dddd-4b8b-8eab-e050253d7f10",
                   "source": "/08d9b620-48de-4247-8f33-360988d3b19b",
                   "time": "2021-01-21T11:14:16.42372Z",
                   "dataschema": "https://api.alfresco.com/schema/event/repo/v1/nodeCreated",
                   "datacontenttype": "application/json",
                   "data": {
-                    "eventGroupId": "4004ca99-9d2a-400d-9d80-8f840e223508",
+                    "eventGroupId": "4004ca99-9d2a-400d-9d80-8f840e223510",
                     "resource": {
                       "@type": "NodeResource",
-                      "id": "d71dd823-82c7-477c-8490-04cb0e826e08",
+                      "id": "d71dd823-82c7-477c-8490-04cb0e826e10",
                       "primaryHierarchy": [ "5f355d16-f824-4173-bf4b-b1ec37ef5549", "93f7edf5-e4d8-4749-9b4c-e45097e2e19d" ],
                       "name": "purchase-order-scan.pdf",
                       "nodeType": "cm:content",
@@ -776,16 +776,16 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                 {
                   "specversion": "1.0",
                   "type": "org.alfresco.event.node.Created",
-                  "id": "368818d9-dddd-4b8b-8eab-e050253d7f09",
+                  "id": "368818d9-dddd-4b8b-8eab-e050253d7f11",
                   "source": "/08d9b620-48de-4247-8f33-360988d3b19b",
                   "time": "2021-01-21T11:14:16.42372Z",
                   "dataschema": "https://api.alfresco.com/schema/event/repo/v1/nodeCreated",
                   "datacontenttype": "application/json",
                   "data": {
-                    "eventGroupId": "4004ca99-9d2a-400d-9d80-8f840e223509",
+                    "eventGroupId": "4004ca99-9d2a-400d-9d80-8f840e223511",
                     "resource": {
                       "@type": "NodeResource",
-                      "id": "d71dd823-82c7-477c-8490-04cb0e826e09",
+                      "id": "d71dd823-82c7-477c-8490-04cb0e826e11",
                       "primaryHierarchy": [ "5f355d16-f824-4173-bf4b-b1ec37ef5549", "93f7edf5-e4d8-4749-9b4c-e45097e2e19d" ],
                       "name": "purchase-order-scan.pdf",
                       "nodeType": "cm:folder",
@@ -832,16 +832,16 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                 {
                   "specversion": "1.0",
                   "type": "org.alfresco.event.node.Updated",
-                  "id": "ae5dac3c-25d0-438d-b148-2084d1ab0510",
+                  "id": "ae5dac3c-25d0-438d-b148-2084d1ab0512",
                   "source": "/08d9b620-48de-4247-8f33-360988d3b19b",
                   "time": "2021-01-26T10:29:42.99524Z",
                   "dataschema": "https://api.alfresco.com/schema/event/repo/v1/nodeUpdated",
                   "datacontenttype": "application/json",
                   "data": {
-                    "eventGroupId": "b5b1ebfe-45fc-4f86-b71b-421996482810",
+                    "eventGroupId": "b5b1ebfe-45fc-4f86-b71b-421996482812",
                     "resource": {
                       "@type": "NodeResource",
-                      "id": "d71dd823-82c7-477c-8490-04cb0e826e10",
+                      "id": "d71dd823-82c7-477c-8490-04cb0e826e12",
                       "name": "purchase-order-scan.pdf",
                       "nodeType": "cm:folder",
                       "createdByUser": {
@@ -892,5 +892,399 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
 
         // then
         containerSupport.expectNoHxIngestMessagesReceived();
+    }
+
+    @Test
+    void testUpdateRequestWithAspectInAllowedFilterAndTypeInAllowedFilterAndAncestorModifiedToFitAllowedFilter()
+    {
+        // given node updated from being denied to be allowed
+        containerSupport.prepareHxInsightToReturnSuccess();
+
+        String repoEvent = """
+                {
+                  "specversion": "1.0",
+                  "type": "org.alfresco.event.node.Updated",
+                  "id": "ae5dac3c-25d0-438d-b148-2084d1ab0513",
+                  "source": "/08d9b620-48de-4247-8f33-360988d3b19b",
+                  "time": "2021-01-26T10:29:42.99524Z",
+                  "dataschema": "https://api.alfresco.com/schema/event/repo/v1/nodeUpdated",
+                  "datacontenttype": "application/json",
+                  "data": {
+                    "eventGroupId": "b5b1ebfe-45fc-4f86-b71b-421996482813",
+                    "resource": {
+                      "@type": "NodeResource",
+                      "id": "d71dd823-82c7-477c-8490-04cb0e826e13",
+                      "primaryHierarchy": [ "5f355d16-f824-4173-bf4b-b1ec37ef5549", "93f7edf5-e4d8-4749-9b4c-e45097e2e19d" ],
+                      "name": "purchase-order-scan.pdf",
+                      "nodeType": "cm:content",
+                      "createdByUser": {
+                        "id": "admin",
+                        "displayName": "Administrator"
+                      },
+                      "createdAt": "2024-03-02T11:14:15.695Z",
+                      "modifiedByUser": {
+                        "id": "abeecher",
+                        "displayName": "Alice Beecher"
+                      },
+                      "modifiedAt": "2024-03-06T10:29:42.529Z",
+                      "content": {
+                        "mimeType": "application/pdf",
+                        "sizeInBytes": 531152,
+                        "encoding": "UTF-8"
+                      },
+                      "properties": {
+                        "cm:title": "Purchase Order",
+                        "cm:versionType": null,
+                        "cm:versionLabel": "1.0",
+                        "cm:taggable": null
+                      },
+                      "aspectNames": [ "cm:versionable", "cm:auditable" ],
+                      "isFolder": false,
+                      "isFile": true
+                    },
+                    "resourceBefore": {
+                      "@type": "NodeResource",
+                      "primaryHierarchy": [ "11111111-1111-1111-1111-111111111111", "5f355d16-f824-4173-bf4b-b1ec37ef5549", "93f7edf5-e4d8-4749-9b4c-e45097e2e19d" ],
+                      "modifiedAt": "2024-03-02T11:14:25.223Z",
+                      "modifiedByUser": {
+                        "id": "admin",
+                        "displayName": "Administrator"
+                      },
+                      "properties": {
+                        "cm:title": null,
+                        "cm:versionType": "MAJOR",
+                        "cm:versionLabel": "1.0",
+                        "cm:taggable": null,
+                        "cm:description": "Old Description"
+                      },
+                      "aspectNames": [ "cm:versionable" ]
+                    }
+                  }
+                }""";
+
+        // when
+        containerSupport.raiseRepoEvent(repoEvent);
+
+        // then send a create event
+        String expectedBody = """
+                [
+                  {
+                     "objectId" : "d71dd823-82c7-477c-8490-04cb0e826e13",
+                     "eventType" : "create",
+                     "properties" : {
+                       "cm:title" : {
+                         "value" : "Purchase Order"
+                       },
+                       "createdAt" : {
+                         "value" : 1709378055695
+                       },
+                       "cm:versionLabel" : {
+                         "value" : "1.0"
+                       },
+                       "createdBy" : {
+                         "value" : "admin"
+                       },
+                       "cm:name" : {
+                         "value" : "purchase-order-scan.pdf"
+                       },
+                       "aspectsNames" : {
+                         "value" : [ "cm:versionable", "cm:auditable" ]
+                       },
+                       "modifiedBy" : {
+                         "value" : "abeecher"
+                       },
+                       "type" : {
+                         "value" : "cm:content"
+                       },
+                       "cm:content" : {
+                         "file" : {
+                           "content-metadata" : {
+                             "size" : 531152,
+                             "name" : "purchase-order-scan.pdf",
+                             "content-type" : "application/pdf"
+                           }
+                         }
+                       }
+                     }
+                   }
+                ]""";
+        containerSupport.expectHxIngestMessageReceived(expectedBody);
+    }
+
+    @Test
+    void testUpdateRequestWithAspectInAllowedFilterAndTypeInAllowedFilterAndAncestorModifiedToFitDeniedFilter()
+    {
+        // given node updated from being allowed to be denied
+        containerSupport.prepareHxInsightToReturnSuccess();
+
+        String repoEvent = """
+                {
+                  "specversion": "1.0",
+                  "type": "org.alfresco.event.node.Updated",
+                  "id": "ae5dac3c-25d0-438d-b148-2084d1ab0514",
+                  "source": "/08d9b620-48de-4247-8f33-360988d3b19b",
+                  "time": "2021-01-26T10:29:42.99524Z",
+                  "dataschema": "https://api.alfresco.com/schema/event/repo/v1/nodeUpdated",
+                  "datacontenttype": "application/json",
+                  "data": {
+                    "eventGroupId": "b5b1ebfe-45fc-4f86-b71b-421996482814",
+                    "resource": {
+                      "@type": "NodeResource",
+                      "id": "d71dd823-82c7-477c-8490-04cb0e826e14",
+                      "primaryHierarchy": [ "11111111-1111-1111-1111-111111111111", "5f355d16-f824-4173-bf4b-b1ec37ef5549", "93f7edf5-e4d8-4749-9b4c-e45097e2e19d" ],
+                      "name": "purchase-order-scan.pdf",
+                      "nodeType": "cm:content",
+                      "createdByUser": {
+                        "id": "admin",
+                        "displayName": "Administrator"
+                      },
+                      "createdAt": "2024-03-02T11:14:15.695Z",
+                      "modifiedByUser": {
+                        "id": "abeecher",
+                        "displayName": "Alice Beecher"
+                      },
+                      "modifiedAt": "2024-03-06T10:29:42.529Z",
+                      "content": {
+                        "mimeType": "application/pdf",
+                        "sizeInBytes": 531152,
+                        "encoding": "UTF-8"
+                      },
+                      "properties": {
+                        "cm:title": "Purchase Order",
+                        "cm:versionType": null,
+                        "cm:versionLabel": "1.0",
+                        "cm:taggable": null
+                      },
+                      "aspectNames": [ "cm:versionable", "cm:auditable" ],
+                      "isFolder": false,
+                      "isFile": true
+                    },
+                    "resourceBefore": {
+                      "@type": "NodeResource",
+                      "primaryHierarchy": [ "5f355d16-f824-4173-bf4b-b1ec37ef5549", "93f7edf5-e4d8-4749-9b4c-e45097e2e19d" ],
+                      "modifiedAt": "2024-03-02T11:14:25.223Z",
+                      "modifiedByUser": {
+                        "id": "admin",
+                        "displayName": "Administrator"
+                      },
+                      "properties": {
+                        "cm:title": null,
+                        "cm:versionType": "MAJOR",
+                        "cm:versionLabel": "1.0",
+                        "cm:taggable": null,
+                        "cm:description": "Old Description"
+                      },
+                      "aspectNames": [ "cm:versionable" ]
+                    }
+                  }
+                }""";
+
+        // when
+        containerSupport.raiseRepoEvent(repoEvent);
+
+        // then send a delete event
+        String expectedBody = """
+                  {
+                      "objectId" : "d71dd823-82c7-477c-8490-04cb0e826e14",
+                      "eventType" : "delete"
+                    }
+                """;
+        containerSupport.expectHxIngestMessageReceived(expectedBody);
+    }
+
+    @Test
+    void testUpdateRequestWithAspectModifiedToFitDeniedFilterAndTypeInAllowedFilterAndAncestorInAllowedFilter()
+    {
+        // given node updated from being denied to be allowed
+        containerSupport.prepareHxInsightToReturnSuccess();
+
+        String repoEvent = """
+                {
+                  "specversion": "1.0",
+                  "type": "org.alfresco.event.node.Updated",
+                  "id": "ae5dac3c-25d0-438d-b148-2084d1ab0515",
+                  "source": "/08d9b620-48de-4247-8f33-360988d3b19b",
+                  "time": "2021-01-26T10:29:42.99524Z",
+                  "dataschema": "https://api.alfresco.com/schema/event/repo/v1/nodeUpdated",
+                  "datacontenttype": "application/json",
+                  "data": {
+                    "eventGroupId": "b5b1ebfe-45fc-4f86-b71b-421996482815",
+                    "resource": {
+                      "@type": "NodeResource",
+                      "id": "d71dd823-82c7-477c-8490-04cb0e826e15",
+                      "primaryHierarchy": [ "5f355d16-f824-4173-bf4b-b1ec37ef5549", "93f7edf5-e4d8-4749-9b4c-e45097e2e19d" ],
+                      "name": "purchase-order-scan.pdf",
+                      "nodeType": "cm:content",
+                      "createdByUser": {
+                        "id": "admin",
+                        "displayName": "Administrator"
+                      },
+                      "createdAt": "2024-03-02T11:14:15.695Z",
+                      "modifiedByUser": {
+                        "id": "abeecher",
+                        "displayName": "Alice Beecher"
+                      },
+                      "modifiedAt": "2024-03-06T10:29:42.529Z",
+                      "content": {
+                        "mimeType": "application/pdf",
+                        "sizeInBytes": 531152,
+                        "encoding": "UTF-8"
+                      },
+                      "properties": {
+                        "cm:title": "Purchase Order",
+                        "cm:versionType": null,
+                        "cm:versionLabel": "1.0",
+                        "cm:taggable": null
+                      },
+                      "aspectNames": [ "cm:versionable", "cm:auditable", "sc:secured" ],
+                      "isFolder": false,
+                      "isFile": true
+                    },
+                    "resourceBefore": {
+                      "@type": "NodeResource",
+                      "modifiedAt": "2024-03-02T11:14:25.223Z",
+                      "modifiedByUser": {
+                        "id": "admin",
+                        "displayName": "Administrator"
+                      },
+                      "properties": {
+                        "cm:title": null,
+                        "cm:versionType": "MAJOR",
+                        "cm:versionLabel": "1.0",
+                        "cm:taggable": null,
+                        "cm:description": "Old Description"
+                      },
+                      "aspectNames": [ "cm:versionable" ]
+                    }
+                  }
+                }""";
+
+        // when
+        containerSupport.raiseRepoEvent(repoEvent);
+
+        // then send a delete event
+        String expectedBody = """
+                  {
+                      "objectId" : "d71dd823-82c7-477c-8490-04cb0e826e15",
+                      "eventType" : "delete"
+                    }
+                """;
+        containerSupport.expectHxIngestMessageReceived(expectedBody);
+    }
+
+    @Test
+    void testUpdateRequestWithAspectModifiedToFitAllowedFilterAndTypeInAllowedFilterAndAncestorInAllowedFilter()
+    {
+        // given node updated from being allowed to be denied
+        containerSupport.prepareHxInsightToReturnSuccess();
+
+        String repoEvent = """
+                {
+                  "specversion": "1.0",
+                  "type": "org.alfresco.event.node.Updated",
+                  "id": "ae5dac3c-25d0-438d-b148-2084d1ab0516",
+                  "source": "/08d9b620-48de-4247-8f33-360988d3b19b",
+                  "time": "2021-01-26T10:29:42.99524Z",
+                  "dataschema": "https://api.alfresco.com/schema/event/repo/v1/nodeUpdated",
+                  "datacontenttype": "application/json",
+                  "data": {
+                    "eventGroupId": "b5b1ebfe-45fc-4f86-b71b-421996482816",
+                    "resource": {
+                      "@type": "NodeResource",
+                      "id": "d71dd823-82c7-477c-8490-04cb0e826e16",
+                      "primaryHierarchy": [ "5f355d16-f824-4173-bf4b-b1ec37ef5549", "93f7edf5-e4d8-4749-9b4c-e45097e2e19d" ],
+                      "name": "purchase-order-scan.pdf",
+                      "nodeType": "cm:content",
+                      "createdByUser": {
+                        "id": "admin",
+                        "displayName": "Administrator"
+                      },
+                      "createdAt": "2024-03-02T11:14:15.695Z",
+                      "modifiedByUser": {
+                        "id": "abeecher",
+                        "displayName": "Alice Beecher"
+                      },
+                      "modifiedAt": "2024-03-06T10:29:42.529Z",
+                      "content": {
+                        "mimeType": "application/pdf",
+                        "sizeInBytes": 531152,
+                        "encoding": "UTF-8"
+                      },
+                      "properties": {
+                        "cm:title": "Purchase Order",
+                        "cm:versionType": null,
+                        "cm:versionLabel": "1.0",
+                        "cm:taggable": null
+                      },
+                      "aspectNames": [ "cm:versionable", "cm:auditable" ],
+                      "isFolder": false,
+                      "isFile": true
+                    },
+                    "resourceBefore": {
+                      "@type": "NodeResource",
+                      "modifiedAt": "2024-03-02T11:14:25.223Z",
+                      "modifiedByUser": {
+                        "id": "admin",
+                        "displayName": "Administrator"
+                      },
+                      "properties": {
+                        "cm:title": null,
+                        "cm:versionType": "MAJOR",
+                        "cm:versionLabel": "1.0",
+                        "cm:taggable": null,
+                        "cm:description": "Old Description"
+                      },
+                      "aspectNames": [ "cm:versionable", "sc:secured" ]
+                    }
+                  }
+                }""";
+
+        // when
+        containerSupport.raiseRepoEvent(repoEvent);
+
+        // then send a create event
+        String expectedBody = """
+                [
+                  {
+                     "objectId" : "d71dd823-82c7-477c-8490-04cb0e826e16",
+                     "eventType" : "create",
+                     "properties" : {
+                       "cm:title" : {
+                         "value" : "Purchase Order"
+                       },
+                       "createdAt" : {
+                         "value" : 1709378055695
+                       },
+                       "cm:versionLabel" : {
+                         "value" : "1.0"
+                       },
+                       "createdBy" : {
+                         "value" : "admin"
+                       },
+                       "cm:name" : {
+                         "value" : "purchase-order-scan.pdf"
+                       },
+                       "aspectsNames" : {
+                         "value" : [ "cm:versionable", "cm:auditable" ]
+                       },
+                       "modifiedBy" : {
+                         "value" : "abeecher"
+                       },
+                       "type" : {
+                         "value" : "cm:content"
+                       },
+                       "cm:content" : {
+                         "file" : {
+                           "content-metadata" : {
+                             "size" : 531152,
+                             "name" : "purchase-order-scan.pdf",
+                             "content-type" : "application/pdf"
+                           }
+                         }
+                       }
+                     }
+                   }
+                ]""";
+        containerSupport.expectHxIngestMessageReceived(expectedBody);
     }
 }

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/EventProcessor.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/EventProcessor.java
@@ -36,8 +36,10 @@ import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.camel.Exchange;
 import org.springframework.stereotype.Component;
 
+import org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.mapper.CamelEventMapper;
 import org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.mapper.RepoEventMapper;
 import org.alfresco.hxi_connector.live_ingester.domain.usecase.content.IngestContentCommand;
 import org.alfresco.hxi_connector.live_ingester.domain.usecase.content.IngestContentCommandHandler;
@@ -59,9 +61,11 @@ public class EventProcessor
     private final IngestContentCommandHandler ingestContentCommandHandler;
     private final DeleteNodeCommandHandler deleteNodeCommandHandler;
     private final RepoEventMapper repoEventMapper;
+    private final CamelEventMapper camelEventMapper;
 
-    public void process(RepoEvent<DataAttributes<NodeResource>> event)
+    public void process(Exchange exchange)
     {
+        RepoEvent<DataAttributes<NodeResource>> event = camelEventMapper.repoEventFrom(exchange);
         handleMetadataPropertiesChange(event);
         handleContentChange(event);
         handleNodeDeleteEvent(event);

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/LiveIngesterEventHandler.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/LiveIngesterEventHandler.java
@@ -56,7 +56,7 @@ public class LiveIngesterEventHandler extends RouteBuilder
                 .transacted()
                 .routeId(ROUTE_ID)
                 .log(DEBUG, "Received repo event : ${header.JMSMessageID}")
-                .filter(exchange -> repoEventFilterHandler.filterNode(camelEventMapper.repoEventFrom(exchange), integrationProperties.alfresco().filter()))
+                .filter(exchange -> repoEventFilterHandler.filterNode(exchange, integrationProperties.alfresco().filter()))
                 .process(exchange -> SecurityContextHolder.setContext(securityContext))
                 .process(exchange -> eventProcessor.process(camelEventMapper.repoEventFrom(exchange)))
                 .end();

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/LiveIngesterEventHandler.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/LiveIngesterEventHandler.java
@@ -35,7 +35,6 @@ import org.springframework.stereotype.Component;
 
 import org.alfresco.hxi_connector.live_ingester.adapters.config.IntegrationProperties;
 import org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.filter.RepoEventFilterHandler;
-import org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.mapper.CamelEventMapper;
 
 @Component
 @RequiredArgsConstructor
@@ -44,7 +43,6 @@ public class LiveIngesterEventHandler extends RouteBuilder
     private static final String ROUTE_ID = "repo-events-consumer";
 
     private final EventProcessor eventProcessor;
-    private final CamelEventMapper camelEventMapper;
     private final IntegrationProperties integrationProperties;
     private final RepoEventFilterHandler repoEventFilterHandler;
 
@@ -58,7 +56,7 @@ public class LiveIngesterEventHandler extends RouteBuilder
                 .log(DEBUG, "Received repo event : ${header.JMSMessageID}")
                 .filter(exchange -> repoEventFilterHandler.filterNode(exchange, integrationProperties.alfresco().filter()))
                 .process(exchange -> SecurityContextHolder.setContext(securityContext))
-                .process(exchange -> eventProcessor.process(camelEventMapper.repoEventFrom(exchange)))
+                .process(eventProcessor::process)
                 .end();
     }
 }

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/filter/AspectFilterApplier.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/filter/AspectFilterApplier.java
@@ -31,11 +31,14 @@ import java.util.Set;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.camel.Exchange;
 import org.apache.commons.collections4.SetUtils;
 import org.springframework.stereotype.Component;
 
 import org.alfresco.hxi_connector.common.repository.filter.CollectionFilter;
 import org.alfresco.hxi_connector.live_ingester.adapters.config.properties.Filter;
+import org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.utils.EventUtils;
+import org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.utils.ExchangeEnricher;
 import org.alfresco.repo.event.v1.model.DataAttributes;
 import org.alfresco.repo.event.v1.model.NodeResource;
 import org.alfresco.repo.event.v1.model.RepoEvent;
@@ -46,13 +49,21 @@ import org.alfresco.repo.event.v1.model.RepoEvent;
 public class AspectFilterApplier implements RepoEventFilterApplier
 {
     @Override
-    public boolean applyFilter(RepoEvent<DataAttributes<NodeResource>> repoEvent, Filter filter)
+    public boolean applyFilter(Exchange exchange, RepoEvent<DataAttributes<NodeResource>> repoEvent, Filter filter)
     {
         final Set<String> aspectNames = SetUtils.emptyIfNull(repoEvent.getData().getResource().getAspectNames());
         final List<String> allowed = filter.aspect().allow();
         final List<String> denied = filter.aspect().deny();
         log.atDebug().log("Applying aspect filters on repo event of id: {}, node id: {}", repoEvent.getId(), repoEvent.getData().getResource().getId());
-        return CollectionFilter.filter(aspectNames, allowed, denied);
+        boolean result = CollectionFilter.filter(aspectNames, allowed, denied);
+        if (EventUtils.isEventTypeUpdated(repoEvent))
+        {
+            final Set<String> aspectNamesBefore = SetUtils.emptyIfNull(repoEvent.getData().getResourceBefore().getAspectNames());
+            boolean resultBefore = CollectionFilter.filter(aspectNamesBefore, allowed, denied);
+            ExchangeEnricher.enrichExchangeAfterFiltering(exchange, resultBefore, result);
+            return resultBefore || result;
+        }
+        return result;
     }
 
 }

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/filter/RepoEventFilterApplier.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/filter/RepoEventFilterApplier.java
@@ -26,6 +26,8 @@
 
 package org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.filter;
 
+import org.apache.camel.Exchange;
+
 import org.alfresco.hxi_connector.live_ingester.adapters.config.properties.Filter;
 import org.alfresco.repo.event.v1.model.DataAttributes;
 import org.alfresco.repo.event.v1.model.NodeResource;
@@ -33,5 +35,5 @@ import org.alfresco.repo.event.v1.model.RepoEvent;
 
 public interface RepoEventFilterApplier
 {
-    boolean applyFilter(RepoEvent<DataAttributes<NodeResource>> repoEvent, Filter filter);
+    boolean applyFilter(Exchange exchange, RepoEvent<DataAttributes<NodeResource>> repoEvent, Filter filter);
 }

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/filter/RepoEventFilterHandler.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/filter/RepoEventFilterHandler.java
@@ -30,9 +30,11 @@ import java.util.List;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.camel.Exchange;
 import org.springframework.stereotype.Component;
 
 import org.alfresco.hxi_connector.live_ingester.adapters.config.properties.Filter;
+import org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.mapper.CamelEventMapper;
 import org.alfresco.repo.event.v1.model.DataAttributes;
 import org.alfresco.repo.event.v1.model.NodeResource;
 import org.alfresco.repo.event.v1.model.RepoEvent;
@@ -42,13 +44,14 @@ import org.alfresco.repo.event.v1.model.RepoEvent;
 @Slf4j
 public class RepoEventFilterHandler
 {
-
+    private final CamelEventMapper camelEventMapper;
     private final List<RepoEventFilterApplier> repoEventFilterAppliers;
 
-    public boolean filterNode(RepoEvent<DataAttributes<NodeResource>> repoEvent, Filter filter)
+    public boolean filterNode(Exchange exchange, Filter filter)
     {
+        RepoEvent<DataAttributes<NodeResource>> repoEvent = camelEventMapper.repoEventFrom(exchange);
         return repoEventFilterAppliers.stream()
                 .peek(f -> log.atDebug().log("Applying filters {} to repo event of id: {}", filter, repoEvent.getId()))
-                .allMatch(f -> f.applyFilter(repoEvent, filter));
+                .allMatch(f -> f.applyFilter(exchange, repoEvent, filter));
     }
 }

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/mapper/CamelEventMapper.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/mapper/CamelEventMapper.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco HX Insight Connector
  * %%
- * Copyright (C) 2023 Alfresco Software Limited
+ * Copyright (C) 2023 - 2024 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * If the software was purchased under a paid Alfresco license, the terms of
@@ -34,6 +34,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.Exchange;
 import org.springframework.stereotype.Component;
 
+import org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.utils.ExchangeEnricher;
 import org.alfresco.hxi_connector.live_ingester.domain.exception.LiveIngesterRuntimeException;
 import org.alfresco.repo.event.v1.model.DataAttributes;
 import org.alfresco.repo.event.v1.model.NodeResource;
@@ -47,15 +48,54 @@ public class CamelEventMapper
 
     private final ObjectMapper mapper;
 
+    /**
+     * This method maps/unmarshalls repo event from Camel exchange to Java object It can alter the original type of event basing on custom Camel exchange property which can be set during node filtering.
+     *
+     * @param exchange
+     *            Camel exchange object
+     * @return mapped repo event
+     */
     public RepoEvent<DataAttributes<NodeResource>> repoEventFrom(Exchange exchange)
     {
         try
         {
-            return mapper.readValue(exchange.getIn().getBody(String.class), new TypeReference<>() {});
+            final RepoEvent<DataAttributes<NodeResource>> repoEventOriginal = mapper.readValue(exchange.getIn().getBody(String.class), new TypeReference<>() {});
+            return RepoEvent.<DataAttributes<NodeResource>> builder()
+                    .setData(repoEventOriginal.getData())
+                    .setDatacontenttype(repoEventOriginal.getDatacontenttype())
+                    .setDataschema(repoEventOriginal.getDataschema())
+                    .setExtensionAttributes(repoEventOriginal.getExtensionAttributes())
+                    .setId(repoEventOriginal.getId())
+                    .setSource(repoEventOriginal.getSource())
+                    .setTime(repoEventOriginal.getTime())
+                    .setType(determineEventType(repoEventOriginal, exchange))
+                    .build();
         }
         catch (JsonProcessingException e)
         {
             throw new LiveIngesterRuntimeException("Event deserialization failed", e);
+        }
+    }
+
+    /**
+     * This method will determine repo event type based on whether custom Camel exchange property is present.
+     *
+     * @param repoEventOriginal
+     *            original repo event
+     * @param exchange
+     *            Camel exchange object
+     * @return event type we want to ingest
+     */
+    private String determineEventType(RepoEvent<DataAttributes<NodeResource>> repoEventOriginal, Exchange exchange)
+    {
+        String eventTypeProperty = exchange.getProperty(ExchangeEnricher.UPDATED_EVENT_TYPE_PROP, String.class);
+        if (eventTypeProperty == null)
+        {
+            return repoEventOriginal.getType();
+        }
+        else
+        {
+            return eventTypeProperty;
         }
     }
 }

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/utils/ExchangeEnricher.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/utils/ExchangeEnricher.java
@@ -1,0 +1,69 @@
+/*-
+ * #%L
+ * Alfresco HX Insight Connector
+ * %%
+ * Copyright (C) 2023 - 2024 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.utils;
+
+import static org.alfresco.repo.event.v1.model.EventType.NODE_CREATED;
+import static org.alfresco.repo.event.v1.model.EventType.NODE_DELETED;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.camel.Exchange;
+import org.springframework.stereotype.Component;
+
+@Component
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Slf4j
+public final class ExchangeEnricher
+{
+
+    public static final String UPDATED_EVENT_TYPE_PROP = "updated-event-type";
+    private static final String ENRICHED_EXCHANGE_MESSAGE = "Enriched exchange after filtering. Set exchange property {} to {}";
+
+    /**
+     * This method will enrich Camel exchange with a property indicating that original event type should be changed to the value of that property. It is called during node filtering as most of the needed logic is already there.
+     *
+     * @param exchange
+     *            Camel exchange object
+     * @param resultBefore
+     *            Filtering result for node resource before
+     * @param result
+     *            Filtering result for current node resource
+     */
+    public static void enrichExchangeAfterFiltering(Exchange exchange, boolean resultBefore, boolean result)
+    {
+        if (resultBefore && !result)
+        {
+            log.atDebug().log(ENRICHED_EXCHANGE_MESSAGE, UPDATED_EVENT_TYPE_PROP, NODE_DELETED.getType());
+            exchange.setProperty(UPDATED_EVENT_TYPE_PROP, NODE_DELETED.getType());
+        }
+        if (!resultBefore && result)
+        {
+            log.atDebug().log(ENRICHED_EXCHANGE_MESSAGE, UPDATED_EVENT_TYPE_PROP, NODE_CREATED.getType());
+            exchange.setProperty(UPDATED_EVENT_TYPE_PROP, NODE_CREATED.getType());
+        }
+    }
+}

--- a/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/EventProcessorTest.java
+++ b/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/EventProcessorTest.java
@@ -35,12 +35,14 @@ import static org.alfresco.repo.event.v1.model.EventType.NODE_CREATED;
 import static org.alfresco.repo.event.v1.model.EventType.NODE_DELETED;
 import static org.alfresco.repo.event.v1.model.EventType.NODE_UPDATED;
 
+import org.apache.camel.Exchange;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.mapper.CamelEventMapper;
 import org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.mapper.RepoEventMapper;
 import org.alfresco.hxi_connector.live_ingester.domain.usecase.content.IngestContentCommand;
 import org.alfresco.hxi_connector.live_ingester.domain.usecase.content.IngestContentCommandHandler;
@@ -72,6 +74,12 @@ class EventProcessorTest
     @Mock
     DeleteNodeCommandHandler deleteNodeCommandHandler;
 
+    @Mock
+    private CamelEventMapper mockCamelEventMapper;
+
+    @Mock
+    private Exchange mockExchange;
+
     @InjectMocks
     EventProcessor eventProcessor;
 
@@ -80,10 +88,11 @@ class EventProcessorTest
     {
         // given
         RepoEvent<DataAttributes<NodeResource>> event = prepareMockCreatedEvent();
+        given(mockCamelEventMapper.repoEventFrom(mockExchange)).willReturn(event);
         given(event.getData().getResource().getContent()).willReturn(null);
 
         // when
-        eventProcessor.process(event);
+        eventProcessor.process(mockExchange);
 
         // then
         then(repoEventMapper).should().mapToIngestNodeCommand(event);
@@ -99,9 +108,10 @@ class EventProcessorTest
         RepoEvent<DataAttributes<NodeResource>> event = mock();
         given(event.getType()).willReturn(NODE_UPDATED.getType());
         given(event.getData()).willReturn(mock());
+        given(mockCamelEventMapper.repoEventFrom(mockExchange)).willReturn(event);
 
         // when
-        eventProcessor.process(event);
+        eventProcessor.process(mockExchange);
 
         // then
         then(repoEventMapper).should().mapToIngestNodeCommand(event);
@@ -118,12 +128,13 @@ class EventProcessorTest
         ContentInfo contentInfo = mock();
         given(contentInfo.getSizeInBytes()).willReturn(CONTENT_SIZE);
         given(event.getData().getResource().getContent()).willReturn(contentInfo);
+        given(mockCamelEventMapper.repoEventFrom(mockExchange)).willReturn(event);
 
         IngestContentCommand ingestContentCommand = mock();
         given(repoEventMapper.mapToIngestContentCommand(event)).willReturn(ingestContentCommand);
 
         // when
-        eventProcessor.process(event);
+        eventProcessor.process(mockExchange);
 
         // then
         then(repoEventMapper).should().mapToIngestNodeCommand(event);
@@ -141,9 +152,10 @@ class EventProcessorTest
         ContentInfo contentInfo = mock();
         given(contentInfo.getSizeInBytes()).willReturn(NO_CONTENT);
         given(event.getData().getResource().getContent()).willReturn(contentInfo);
+        given(mockCamelEventMapper.repoEventFrom(mockExchange)).willReturn(event);
 
         // when
-        eventProcessor.process(event);
+        eventProcessor.process(mockExchange);
 
         // then
         then(repoEventMapper).should().mapToIngestNodeCommand(event);
@@ -162,12 +174,13 @@ class EventProcessorTest
         given(contentInfo.getSizeInBytes()).willReturn(CONTENT_SIZE);
         given(event.getData().getResource().getContent()).willReturn(contentInfo);
         given(event.getData().getResourceBefore().getContent()).willReturn(mock());
+        given(mockCamelEventMapper.repoEventFrom(mockExchange)).willReturn(event);
 
         IngestContentCommand ingestContentCommand = mock();
         given(repoEventMapper.mapToIngestContentCommand(event)).willReturn(ingestContentCommand);
 
         // when
-        eventProcessor.process(event);
+        eventProcessor.process(mockExchange);
 
         // then
         then(repoEventMapper).should().mapToIngestNodeCommand(event);
@@ -186,9 +199,10 @@ class EventProcessorTest
         given(contentInfo.getSizeInBytes()).willReturn(CONTENT_SIZE);
         given(event.getData().getResource().getContent()).willReturn(contentInfo);
         given(event.getData().getResourceBefore().getContent()).willReturn(null);
+        given(mockCamelEventMapper.repoEventFrom(mockExchange)).willReturn(event);
 
         // when
-        eventProcessor.process(event);
+        eventProcessor.process(mockExchange);
 
         // then
         then(repoEventMapper).should().mapToIngestNodeCommand(event);
@@ -205,11 +219,12 @@ class EventProcessorTest
         RepoEvent<DataAttributes<NodeResource>> event = mock();
         given(event.getType()).willReturn(NODE_DELETED.getType());
         given(event.getData()).willReturn(mock());
+        given(mockCamelEventMapper.repoEventFrom(mockExchange)).willReturn(event);
         DeleteNodeCommand deleteNodeCommand = mock();
         given(repoEventMapper.mapToDeleteNodeCommand(event)).willReturn(deleteNodeCommand);
 
         // when
-        eventProcessor.process(event);
+        eventProcessor.process(mockExchange);
 
         // then
         then(deleteNodeCommandHandler).should().handle(deleteNodeCommand);

--- a/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/filter/AncestorFilterApplierTest.java
+++ b/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/filter/AncestorFilterApplierTest.java
@@ -27,11 +27,19 @@ package org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.f
 
 import static java.util.Collections.emptyList;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import static org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.utils.ExchangeEnricher.UPDATED_EVENT_TYPE_PROP;
+import static org.alfresco.repo.event.v1.model.EventType.NODE_CREATED;
+import static org.alfresco.repo.event.v1.model.EventType.NODE_DELETED;
+import static org.alfresco.repo.event.v1.model.EventType.NODE_UPDATED;
 
 import java.util.List;
 
+import org.apache.camel.Exchange;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -48,6 +56,7 @@ import org.alfresco.repo.event.v1.model.RepoEvent;
 class AncestorFilterApplierTest
 {
     private static final String ANCESTOR = "parent-node-id";
+    private static final String GRAND_ANCESTOR = "grandparent-node-id";
     @Mock
     private RepoEvent<DataAttributes<NodeResource>> mockRepoEvent;
     @Mock
@@ -55,9 +64,13 @@ class AncestorFilterApplierTest
     @Mock
     private NodeResource mockResource;
     @Mock
+    private NodeResource mockResourceBefore;
+    @Mock
     private Filter mockFilter;
     @Mock
     private Filter.Path mockPath;
+    @Mock
+    private Exchange mockExchange;
 
     @InjectMocks
     private AncestorFilterApplier objectUnderTest;
@@ -78,7 +91,7 @@ class AncestorFilterApplierTest
         given(mockPath.deny()).willReturn(emptyList());
 
         // when
-        boolean result = objectUnderTest.applyFilter(mockRepoEvent, mockFilter);
+        boolean result = objectUnderTest.applyFilter(mockExchange, mockRepoEvent, mockFilter);
 
         // then
         assertTrue(result);
@@ -92,9 +105,93 @@ class AncestorFilterApplierTest
         given(mockPath.deny()).willReturn(emptyList());
 
         // when
-        boolean result = objectUnderTest.applyFilter(mockRepoEvent, mockFilter);
+        boolean result = objectUnderTest.applyFilter(mockExchange, mockRepoEvent, mockFilter);
 
         // then
         assertFalse(result);
+    }
+
+    @Test
+    void shouldNotEnrichExchangeWhenRepoEventTypeCreate()
+    {
+        given(mockPath.allow()).willReturn(List.of(GRAND_ANCESTOR));
+        given(mockPath.deny()).willReturn(emptyList());
+        given(mockRepoEvent.getType()).willReturn(NODE_CREATED.getType());
+        given(mockResource.getPrimaryHierarchy()).willReturn(List.of(ANCESTOR));
+
+        // when
+        boolean result = objectUnderTest.applyFilter(mockExchange, mockRepoEvent, mockFilter);
+
+        then(mockExchange).shouldHaveNoInteractions();
+        assertFalse(result);
+    }
+
+    @Test
+    void shouldNotEnrichExchangeWhenRepoEventTypeDelete()
+    {
+        given(mockPath.allow()).willReturn(List.of(GRAND_ANCESTOR));
+        given(mockPath.deny()).willReturn(emptyList());
+        given(mockRepoEvent.getType()).willReturn(NODE_DELETED.getType());
+        given(mockResource.getPrimaryHierarchy()).willReturn(List.of(ANCESTOR));
+
+        // when
+        boolean result = objectUnderTest.applyFilter(mockExchange, mockRepoEvent, mockFilter);
+
+        then(mockExchange).shouldHaveNoInteractions();
+        assertFalse(result);
+    }
+
+    @Test
+    void shouldNotEnrichExchangeWhenRepoEventTypeUpdateAndFilteringResultNotChanged()
+    {
+        given(mockPath.allow()).willReturn(List.of(GRAND_ANCESTOR));
+        given(mockPath.deny()).willReturn(emptyList());
+        given(mockRepoEvent.getType()).willReturn(NODE_UPDATED.getType());
+        given(mockResource.getPrimaryHierarchy()).willReturn(List.of(ANCESTOR));
+        given(mockData.getResourceBefore()).willReturn(mockResourceBefore);
+        given(mockResourceBefore.getPrimaryHierarchy()).willReturn(List.of(ANCESTOR));
+
+        // when
+        boolean result = objectUnderTest.applyFilter(mockExchange, mockRepoEvent, mockFilter);
+
+        then(mockExchange).shouldHaveNoInteractions();
+        assertFalse(result);
+    }
+
+    @Test
+    void shouldEnrichExchangeWhenRepoEventTypeUpdateAndFilteringResultChangedFromAllowedToDenied()
+    {
+        given(mockPath.allow()).willReturn(emptyList());
+        given(mockPath.deny()).willReturn(List.of(GRAND_ANCESTOR));
+        given(mockRepoEvent.getType()).willReturn(NODE_UPDATED.getType());
+        given(mockResource.getPrimaryHierarchy()).willReturn(List.of(GRAND_ANCESTOR, ANCESTOR));
+        given(mockData.getResourceBefore()).willReturn(mockResourceBefore);
+        given(mockResourceBefore.getPrimaryHierarchy()).willReturn(List.of(ANCESTOR));
+
+        // when
+        boolean result = objectUnderTest.applyFilter(mockExchange, mockRepoEvent, mockFilter);
+
+        then(mockExchange).should().setProperty(UPDATED_EVENT_TYPE_PROP, NODE_DELETED.getType());
+        then(mockExchange).shouldHaveNoMoreInteractions();
+        // needs to further process delete event
+        assertTrue(result);
+    }
+
+    @Test
+    void shouldEnrichExchangeWhenRepoEventTypeUpdateAndFilteringResultChangedFromDeniedToAllowed()
+    {
+        given(mockPath.allow()).willReturn(List.of(GRAND_ANCESTOR));
+        given(mockPath.deny()).willReturn(emptyList());
+        given(mockRepoEvent.getType()).willReturn(NODE_UPDATED.getType());
+        given(mockResource.getPrimaryHierarchy()).willReturn(List.of(GRAND_ANCESTOR, ANCESTOR));
+        given(mockData.getResourceBefore()).willReturn(mockResourceBefore);
+        given(mockResourceBefore.getPrimaryHierarchy()).willReturn(List.of(ANCESTOR));
+
+        // when
+        boolean result = objectUnderTest.applyFilter(mockExchange, mockRepoEvent, mockFilter);
+
+        then(mockExchange).should().setProperty(UPDATED_EVENT_TYPE_PROP, NODE_CREATED.getType());
+        then(mockExchange).shouldHaveNoMoreInteractions();
+        assertTrue(result);
     }
 }

--- a/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/mapper/CamelEventMapperTest.java
+++ b/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/mapper/CamelEventMapperTest.java
@@ -1,0 +1,107 @@
+/*-
+ * #%L
+ * Alfresco HX Insight Connector
+ * %%
+ * Copyright (C) 2023 - 2024 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.mapper;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import static org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.utils.ExchangeEnricher.UPDATED_EVENT_TYPE_PROP;
+import static org.alfresco.repo.event.v1.model.EventType.NODE_CREATED;
+import static org.alfresco.repo.event.v1.model.EventType.NODE_DELETED;
+import static org.alfresco.repo.event.v1.model.EventType.NODE_UPDATED;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.SneakyThrows;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.alfresco.repo.event.v1.model.DataAttributes;
+import org.alfresco.repo.event.v1.model.NodeResource;
+import org.alfresco.repo.event.v1.model.RepoEvent;
+
+@ExtendWith(MockitoExtension.class)
+class CamelEventMapperTest
+{
+
+    @Mock
+    private ObjectMapper mockMapper;
+    @Mock
+    private Exchange mockExchange;
+    @Mock
+    private Message mockMessage;
+
+    @InjectMocks
+    private CamelEventMapper objectUnderTest;
+
+    @Test
+    @SneakyThrows
+    void givenExchangePropertyNotPresent_whenMapping_thenEventTypeNotAltered()
+    {
+        given(mockExchange.getIn()).willReturn(mockMessage);
+        final String mockBody = "mockBody";
+        given(mockMessage.getBody(any())).willReturn(mockBody);
+        final String eventType = NODE_UPDATED.getType();
+        RepoEvent<DataAttributes<NodeResource>> originalEvent = RepoEvent.<DataAttributes<NodeResource>> builder()
+                .setType(eventType)
+                .build();
+        given(mockMapper.readValue(any(String.class), any(TypeReference.class))).willReturn(originalEvent);
+
+        // when
+        RepoEvent<DataAttributes<NodeResource>> repoEvent = objectUnderTest.repoEventFrom(mockExchange);
+
+        // then
+        assertEquals(eventType, repoEvent.getType());
+    }
+
+    @Test
+    @SneakyThrows
+    void givenExchangePropertyPresent_whenMapping_thenEventTypeIsAltered()
+    {
+        given(mockExchange.getIn()).willReturn(mockMessage);
+        final String mockBody = "mockBody";
+        given(mockMessage.getBody(any())).willReturn(mockBody);
+        final String eventType = NODE_CREATED.getType();
+        RepoEvent<DataAttributes<NodeResource>> originalEvent = RepoEvent.<DataAttributes<NodeResource>> builder()
+                .setType(eventType)
+                .build();
+        final String nodeDeletedType = NODE_DELETED.getType();
+        given(mockExchange.getProperty(UPDATED_EVENT_TYPE_PROP, String.class)).willReturn(nodeDeletedType);
+        given(mockMapper.readValue(any(String.class), any(TypeReference.class))).willReturn(originalEvent);
+
+        // when
+        final RepoEvent<DataAttributes<NodeResource>> repoEvent = objectUnderTest.repoEventFrom(mockExchange);
+
+        // then
+        assertEquals(nodeDeletedType, repoEvent.getType());
+    }
+}

--- a/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/utils/ExchangeEnricherTest.java
+++ b/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/utils/ExchangeEnricherTest.java
@@ -1,0 +1,80 @@
+/*-
+ * #%L
+ * Alfresco HX Insight Connector
+ * %%
+ * Copyright (C) 2023 - 2024 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.utils;
+
+import static org.mockito.BDDMockito.then;
+
+import static org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.utils.ExchangeEnricher.UPDATED_EVENT_TYPE_PROP;
+import static org.alfresco.repo.event.v1.model.EventType.NODE_CREATED;
+import static org.alfresco.repo.event.v1.model.EventType.NODE_DELETED;
+
+import org.apache.camel.Exchange;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ExchangeEnricherTest
+{
+
+    @Mock
+    private Exchange mockExchange;
+
+    @Test
+    void whenFilteringResultHasNotChanged_thenExchangeIsNotEnriched()
+    {
+        // when
+        ExchangeEnricher.enrichExchangeAfterFiltering(mockExchange, true, true);
+
+        then(mockExchange).shouldHaveNoInteractions();
+
+        // when
+        ExchangeEnricher.enrichExchangeAfterFiltering(mockExchange, false, false);
+
+        then(mockExchange).shouldHaveNoInteractions();
+    }
+
+    @Test
+    void whenFilteringResultChangedFromAllowedToDenied_thenExchangeEnrichedWithDeleteProperty()
+    {
+        // when
+        ExchangeEnricher.enrichExchangeAfterFiltering(mockExchange, true, false);
+
+        then(mockExchange).should().setProperty(UPDATED_EVENT_TYPE_PROP, NODE_DELETED.getType());
+        then(mockExchange).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    void whenFilteringResultChangedFromDeniedToAllowed_thenExchangeEnrichedWithCreateProperty()
+    {
+        // when
+        ExchangeEnricher.enrichExchangeAfterFiltering(mockExchange, false, true);
+
+        then(mockExchange).should().setProperty(UPDATED_EVENT_TYPE_PROP, NODE_CREATED.getType());
+        then(mockExchange).shouldHaveNoMoreInteractions();
+    }
+}

--- a/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/utils/ExchangeEnricherTest.java
+++ b/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/utils/ExchangeEnricherTest.java
@@ -38,6 +38,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 class ExchangeEnricherTest
 {
 


### PR DESCRIPTION
This may not be the neatest solution but I think it is optimal enough to not degrade performance as most of logic is included in the filtering logic.
1. Main live ingester `Camel` route (`LiveIngesterEventHandler`) is now handling only `Camel`'s `Exchange` object (that should make it easier to get rid of `Camel` in the future)
2. Filtering logic for update events can enhance `Exchange` object with a custom property indicating a `CREATE` or `DELETE` event type needs to be sent to HxI.
3. When above mentioned `Exchange` property is present, `CamelEventMapper` will use it to map event type from `Exchange` to `RepoEvent`.