### PR TITLE
ACS-7473: [HxI LI Integration] Should return field values only as non-empty strings

### DIFF
--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/bulk_ingester/BulkIngesterEventIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/bulk_ingester/BulkIngesterEventIntegrationTest.java
@@ -66,7 +66,7 @@ public class BulkIngesterEventIntegrationTest extends E2ETestBase
                     "eventType" : "create",
                     "properties" : {
                       "type": {"value": "cm:category"},
-                      "createdAt": {"value": 1707153552},
+                      "createdAt": {"value": "1707153552"},
                       "createdBy": {"value": "System"},
                       "modifiedBy": {"value": "admin"},
                       "aspectsNames": {"value": ["cm:auditable"]},
@@ -119,10 +119,10 @@ public class BulkIngesterEventIntegrationTest extends E2ETestBase
                       "createdBy": {"value": "admin"},
                       "modifiedBy": {"value": "hr_user"},
                       "aspectsNames": {"value": ["cm:indexControl", "cm:auditable"]},
-                      "createdAt": {"value": 1308061016},
+                      "createdAt": {"value": "1308061016"},
                       "cm:name": {"value": "dashboard.xml"},
-                      "cm:isContentIndexed": {"value": true},
-                      "cm:isIndexed": {"value": false},
+                      "cm:isContentIndexed": {"value": "true"},
+                      "cm:isIndexed": {"value": "false"},
                       "cm:content": {
                         "file": {
                           "content-metadata": {

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/CreateRequestIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/CreateRequestIntegrationTest.java
@@ -95,8 +95,8 @@ public class CreateRequestIntegrationTest extends E2ETestBase
                     "objectId": "d71dd823-82c7-477c-8490-04cb0e826e65",
                     "eventType": "create",
                     "properties": {
-                      "cm:autoVersion": {"value": true},
-                      "createdAt": {"value": 1611227655695},
+                      "cm:autoVersion": {"value": "true"},
+                      "createdAt": {"value": "1611227655695"},
                       "cm:versionType": {"value": "MAJOR"},
                       "aspectsNames": {"value": ["cm:versionable", "cm:auditable"]},
                       "cm:name": {"value": "purchase-order-scan.doc"},

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/RequestFiltersIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/RequestFiltersIntegrationTest.java
@@ -106,8 +106,8 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                     "objectId": "d71dd823-82c7-477c-8490-04cb0e826e01",
                     "eventType": "create",
                     "properties": {
-                      "cm:autoVersion": {"value": true},
-                      "createdAt": {"value": 1709378055695},
+                      "cm:autoVersion": {"value": "true"},
+                      "createdAt": {"value": "1709378055695"},
                       "cm:versionType": {"value": "MAJOR"},
                       "aspectsNames": {"value": ["cm:versionable", "cm:auditable"]},
                       "cm:name": {"value": "purchase-order-scan.pdf"},
@@ -259,8 +259,8 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                     "objectId": "d71dd823-82c7-477c-8490-04cb0e826e03",
                     "eventType": "create",
                     "properties": {
-                      "cm:autoVersion": {"value": true},
-                      "createdAt": {"value": 1709378055695},
+                      "cm:autoVersion": {"value": "true"},
+                      "createdAt": {"value": "1709378055695"},
                       "cm:versionType": {"value": "MAJOR"},
                       "aspectsNames": {"value": ["cm:versionable", "cm:auditable", "cm:classifiable"]},
                       "cm:name": {"value": "purchase-order-scan.pdf"},

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/util/ContainerSupport.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/util/ContainerSupport.java
@@ -51,7 +51,6 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import jakarta.jms.Connection;
@@ -264,13 +263,15 @@ public class ContainerSupport
     @SneakyThrows
     public void expectFileUploadedToS3(String expectedFile)
     {
-        List<String> actualBucketContent = localStorageClient.listBucketContent(BUCKET_NAME);
+        retryWithBackoff(() -> {
+            assertThat(localStorageClient.listBucketContent(BUCKET_NAME)).contains(OBJECT_KEY);
+        });
+
         @Cleanup
         InputStream expectedInputStream = Files.newInputStream(Paths.get("src/integration-test/resources/" + expectedFile));
         @Cleanup
         InputStream bucketFileInputStream = localStorageClient.downloadBucketObject(BUCKET_NAME, OBJECT_KEY);
 
-        assertThat(actualBucketContent).contains(OBJECT_KEY);
         assertThat(expectedInputStream).hasSameContentAs(bucketFileInputStream);
     }
 }

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/config/jackson/UpdateNodeEventSerializer.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/config/jackson/UpdateNodeEventSerializer.java
@@ -32,12 +32,17 @@ import static org.alfresco.hxi_connector.live_ingester.adapters.messaging.hx_ins
 import static org.alfresco.hxi_connector.live_ingester.adapters.messaging.hx_insight.model.FieldType.VALUE;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
@@ -63,6 +68,7 @@ public class UpdateNodeEventSerializer extends StdSerializer<UpdateNodeEvent>
     }
 
     @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public void serialize(UpdateNodeEvent event, JsonGenerator jgen, SerializerProvider provider)
     {
         try
@@ -71,17 +77,35 @@ public class UpdateNodeEventSerializer extends StdSerializer<UpdateNodeEvent>
             jgen.writeStartObject();
 
             jgen.writeStringField("objectId", event.getObjectId());
-
             jgen.writeStringField("eventType", serializeEventType(event.getEventType()));
 
             if (!event.getMetadataPropertiesToSet().isEmpty() || !event.getContentPropertiesToSet().isEmpty())
             {
                 jgen.writeObjectFieldStart("properties");
+                // @formatter:off
                 event.getMetadataPropertiesToSet().values().stream()
-                        .filter(property -> property.value() != null)
-                        .map(property -> new NodeProperty<>(property.name(), Objects.toString(property.value())))
-                        .filter(property -> StringUtils.isNotEmpty(property.value()))
-                        .forEach(property -> writeProperty(jgen, VALUE, property.name(), property.value()));
+                    .filter(property -> property.value() != null)
+                    .map(property -> Optional.of(property)
+                        .filter(p -> p.value() instanceof Collection)
+                        .map(p -> new NodeProperty(p.name(), ((Collection<?>) p.value()).stream()
+                            .filter(Objects::nonNull)
+                            .map(Objects::toString)
+                            .collect(Collectors.toList())))
+                        .orElse(property))
+                    .map(property -> Optional.of(property)
+                        .filter(p -> p.value() instanceof Map)
+                        .map(p -> new NodeProperty(p.name(), ((Map<?, ?>) p.value()).entrySet().stream()
+                            .filter(entry -> Objects.nonNull(entry.getValue()))
+                            .map(entry -> Map.entry(entry.getKey(), Objects.toString(entry.getValue())))
+                            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))))
+                        .orElse(property))
+                    .map(property -> Optional.of(property)
+                        .filter(p -> ClassUtils.isPrimitiveOrWrapper(p.value().getClass()) || p.value() instanceof String)
+                        .map(p -> new NodeProperty<>(p.name(), Objects.toString(p.value())))
+                        .filter(p -> StringUtils.isNotEmpty(p.value()))
+                        .orElse(property))
+                    .forEach(property -> writeProperty(jgen, VALUE, property.name(), property.value()));
+                // @formatter:on
                 event.getContentPropertiesToSet().values().forEach(property -> writeProperty(jgen, FILE, property.propertyName(), new FileMetadata(property)));
                 jgen.writeEndObject();
             }

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/config/jackson/UpdateNodeEventSerializer.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/config/jackson/UpdateNodeEventSerializer.java
@@ -32,16 +32,19 @@ import static org.alfresco.hxi_connector.live_ingester.adapters.messaging.hx_ins
 import static org.alfresco.hxi_connector.live_ingester.adapters.messaging.hx_insight.model.FieldType.VALUE;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.Set;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
 import org.alfresco.hxi_connector.live_ingester.adapters.config.jackson.exception.JsonSerializationException;
 import org.alfresco.hxi_connector.live_ingester.adapters.messaging.hx_insight.model.FieldType;
 import org.alfresco.hxi_connector.live_ingester.adapters.messaging.hx_insight.model.FileMetadata;
+import org.alfresco.hxi_connector.live_ingester.domain.ports.ingestion_engine.NodeProperty;
 import org.alfresco.hxi_connector.live_ingester.domain.ports.ingestion_engine.UpdateNodeEvent;
 import org.alfresco.hxi_connector.live_ingester.domain.usecase.metadata.model.EventType;
 
@@ -74,7 +77,11 @@ public class UpdateNodeEventSerializer extends StdSerializer<UpdateNodeEvent>
             if (!event.getMetadataPropertiesToSet().isEmpty() || !event.getContentPropertiesToSet().isEmpty())
             {
                 jgen.writeObjectFieldStart("properties");
-                event.getMetadataPropertiesToSet().values().forEach(property -> writeProperty(jgen, VALUE, property.name(), property.value()));
+                event.getMetadataPropertiesToSet().values().stream()
+                        .filter(property -> property.value() != null)
+                        .map(property -> new NodeProperty<>(property.name(), Objects.toString(property.value())))
+                        .filter(property -> StringUtils.isNotEmpty(property.value()))
+                        .forEach(property -> writeProperty(jgen, VALUE, property.name(), property.value()));
                 event.getContentPropertiesToSet().values().forEach(property -> writeProperty(jgen, FILE, property.propertyName(), new FileMetadata(property)));
                 jgen.writeEndObject();
             }

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/config/jackson/UpdateNodeEventSerializer.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/config/jackson/UpdateNodeEventSerializer.java
@@ -32,12 +32,9 @@ import static org.alfresco.hxi_connector.live_ingester.adapters.messaging.hx_ins
 import static org.alfresco.hxi_connector.live_ingester.adapters.messaging.hx_insight.model.FieldType.VALUE;
 
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
@@ -86,23 +83,9 @@ public class UpdateNodeEventSerializer extends StdSerializer<UpdateNodeEvent>
                 event.getMetadataPropertiesToSet().values().stream()
                     .filter(property -> property.value() != null)
                     .map(property -> Optional.of(property)
-                        .filter(p -> p.value() instanceof Collection)
-                        .map(p -> new NodeProperty(p.name(), ((Collection<?>) p.value()).stream()
-                            .filter(Objects::nonNull)
-                            .map(Objects::toString)
-                            .collect(Collectors.toList())))
-                        .orElse(property))
-                    .map(property -> Optional.of(property)
-                        .filter(p -> p.value() instanceof Map)
-                        .map(p -> new NodeProperty(p.name(), ((Map<?, ?>) p.value()).entrySet().stream()
-                            .filter(entry -> Objects.nonNull(entry.getValue()))
-                            .map(entry -> Map.entry(entry.getKey(), Objects.toString(entry.getValue())))
-                            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))))
-                        .orElse(property))
-                    .map(property -> Optional.of(property)
                         .filter(p -> ClassUtils.isPrimitiveOrWrapper(p.value().getClass()) || p.value() instanceof String)
-                        .map(p -> new NodeProperty<>(p.name(), Objects.toString(p.value())))
-                        .filter(p -> StringUtils.isNotEmpty(p.value()))
+                        .map(p -> new NodeProperty(p.name(), Objects.toString(p.value())))
+                        .filter(p -> StringUtils.isNotEmpty((String) p.value()))
                         .orElse(property))
                     .forEach(property -> writeProperty(jgen, VALUE, property.name(), property.value()));
                 // @formatter:on

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/config/jackson/UpdateNodeEventSerializer.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/config/jackson/UpdateNodeEventSerializer.java
@@ -84,9 +84,9 @@ public class UpdateNodeEventSerializer extends StdSerializer<UpdateNodeEvent>
                     .filter(property -> property.value() != null)
                     .map(property -> Optional.of(property)
                         .filter(p -> ClassUtils.isPrimitiveOrWrapper(p.value().getClass()) || p.value() instanceof String)
-                        .map(p -> new NodeProperty(p.name(), Objects.toString(p.value())))
-                        .filter(p -> StringUtils.isNotEmpty((String) p.value()))
-                        .orElse(property))
+                        .map(p -> new NodeProperty<>(p.name(), Objects.toString(p.value())))
+                        .filter(p -> StringUtils.isNotEmpty(p.value()))
+                        .orElse((NodeProperty<String>) property))
                     .forEach(property -> writeProperty(jgen, VALUE, property.name(), property.value()));
                 // @formatter:on
                 event.getContentPropertiesToSet().values().forEach(property -> writeProperty(jgen, FILE, property.propertyName(), new FileMetadata(property)));

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/config/jackson/UpdateNodeEventSerializer.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/config/jackson/UpdateNodeEventSerializer.java
@@ -65,7 +65,7 @@ public class UpdateNodeEventSerializer extends StdSerializer<UpdateNodeEvent>
     }
 
     @Override
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({"unchecked"})
     public void serialize(UpdateNodeEvent event, JsonGenerator jgen, SerializerProvider provider)
     {
         try

--- a/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/config/jackson/UpdateNodeEventSerializerTest.java
+++ b/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/config/jackson/UpdateNodeEventSerializerTest.java
@@ -30,7 +30,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import static org.alfresco.hxi_connector.common.constant.NodeProperties.CONTENT_PROPERTY;
 import static org.alfresco.hxi_connector.common.constant.NodeProperties.CREATED_AT_PROPERTY;
-import static org.alfresco.hxi_connector.common.constant.NodeProperties.CREATED_BY_PROPERTY;
 import static org.alfresco.hxi_connector.common.constant.NodeProperties.MODIFIED_BY_PROPERTY;
 import static org.alfresco.hxi_connector.live_ingester.domain.usecase.metadata.model.EventType.CREATE;
 import static org.alfresco.hxi_connector.live_ingester.domain.usecase.metadata.model.EventType.UPDATE;
@@ -81,7 +80,7 @@ class UpdateNodeEventSerializerTest
                     "objectId": "%s",
                     "eventType": "create",
                     "properties": {
-                      "createdAt": {"value": 10000},
+                      "createdAt": {"value": "10000"},
                       "modifiedBy": {"value": "000-000-000"}
                     }
                   }
@@ -104,29 +103,6 @@ class UpdateNodeEventSerializerTest
                     "objectId": "%s",
                     "eventType": "update",
                     "removedProperties": [ "createdAt", "modifiedBy" ]
-                  }
-                ]""".formatted(NODE_ID);
-        String actualJson = serialize(event);
-
-        assertJsonEquals(expectedJson, actualJson);
-    }
-
-    @Test
-    public void canCopeWithNullUsers()
-    {
-        UpdateNodeEvent event = new UpdateNodeEvent(NODE_ID, CREATE)
-                .addMetadataInstruction(new NodeProperty<>(CREATED_BY_PROPERTY, null))
-                .addMetadataInstruction(new NodeProperty<>(MODIFIED_BY_PROPERTY, null));
-
-        String expectedJson = """
-                [
-                  {
-                    "objectId": "%s",
-                    "eventType": "create",
-                    "properties": {
-                      "createdBy": {"value": null},
-                      "modifiedBy": {"value": null}
-                    }
                   }
                 ]""".formatted(NODE_ID);
         String actualJson = serialize(event);

--- a/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/config/jackson/UpdateNodeEventSerializerTest.java
+++ b/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/config/jackson/UpdateNodeEventSerializerTest.java
@@ -148,7 +148,7 @@ class UpdateNodeEventSerializerTest
                 .addMetadataInstruction(new NodeProperty<>(CREATED_AT_PROPERTY, 10000L))
                 .addMetadataInstruction(new NodeProperty<>("someProperty", new Object() {
                     @Getter
-                    final String key = "val";
+                    String key = "val";
                 }));
 
         String actualJson = serialize(event);

--- a/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/config/jackson/UpdateNodeEventSerializerTest.java
+++ b/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/config/jackson/UpdateNodeEventSerializerTest.java
@@ -168,6 +168,72 @@ class UpdateNodeEventSerializerTest
     }
 
     @Test
+    public void shouldNotSerializeEmptyPropertyToSet()
+    {
+        UpdateNodeEvent event = new UpdateNodeEvent(NODE_ID, CREATE)
+                .addMetadataInstruction(new NodeProperty<>(CREATED_AT_PROPERTY, 10000L))
+                .addMetadataInstruction(new NodeProperty<>("someProperty", ""));
+
+        String actualJson = serialize(event);
+
+        String expectedJson = """
+                [
+                  {
+                    "objectId": "%s",
+                    "eventType": "create",
+                    "properties": {
+                      "createdAt": {"value": "10000"}
+                    }
+                  }
+                ]""".formatted(NODE_ID);
+        assertJsonEquals(expectedJson, actualJson);
+    }
+
+    @Test
+    public void shouldNotSerializeEmptyCollectionToSet()
+    {
+        UpdateNodeEvent event = new UpdateNodeEvent(NODE_ID, CREATE)
+                .addMetadataInstruction(new NodeProperty<>(CREATED_AT_PROPERTY, 10000L))
+                .addMetadataInstruction(new NodeProperty<>("someProperty", List.of()));
+
+        String actualJson = serialize(event);
+
+        String expectedJson = """
+                [
+                  {
+                    "objectId": "%s",
+                    "eventType": "create",
+                    "properties": {
+                      "createdAt": {"value": "10000"}
+                    }
+                  }
+                ]""".formatted(NODE_ID);
+        assertJsonEquals(expectedJson, actualJson);
+    }
+
+    @Test
+    public void shouldNotSerializeEmptyMapToSet()
+    {
+        UpdateNodeEvent event = new UpdateNodeEvent(NODE_ID, CREATE)
+                .addMetadataInstruction(new NodeProperty<>(CREATED_AT_PROPERTY, 10000L))
+                .addMetadataInstruction(new NodeProperty<>("someProperty", Map.of()));
+
+        String actualJson = serialize(event);
+
+        String expectedJson = """
+                [
+                  {
+                    "objectId": "%s",
+                    "eventType": "create",
+                    "properties": {
+                      "createdAt": {"value": "10000"}
+                    }
+                  }
+                ]""".formatted(NODE_ID);
+        assertJsonEquals(expectedJson, actualJson);
+    }
+
+    @Test
     public void shouldSerializePropertiesToUnset()
     {
         UpdateNodeEvent event = new UpdateNodeEvent(NODE_ID, UPDATE)


### PR DESCRIPTION
[HxI LI Integration] Ingestion event handler should return field values only as non-empty strings
https://hyland.atlassian.net/browse/ACS-7473