### PR TITLE
ACS-6906: Add mime type configuration for pdf transforms.

### DIFF
--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/transform/response/ATSTransformResponseHandlerTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/transform/response/ATSTransformResponseHandlerTest.java
@@ -220,6 +220,7 @@ class ATSTransformResponseHandlerTest
                                             RESPONSE_ENDPOINT,
                                             retryIngestion,
                                             retryTransformation),
+                                    mock(),
                                     mock()),
                             mock()),
                     mock());

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/config/properties/Transform.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/config/properties/Transform.java
@@ -27,6 +27,7 @@ package org.alfresco.hxi_connector.live_ingester.adapters.config.properties;
 
 import static java.util.Objects.requireNonNullElseGet;
 
+import java.util.Map;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
@@ -34,7 +35,7 @@ import jakarta.validation.constraints.Positive;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.boot.context.properties.bind.DefaultValue;
 
-public record Transform(@NotNull Request request, @NotNull Response response, @NotNull SharedFileStore sharedFileStore)
+public record Transform(@NotNull Request request, @NotNull Response response, @NotNull SharedFileStore sharedFileStore, @NotNull MimeType mimeType)
 {
     public record Request(@NotBlank String endpoint, @Positive @DefaultValue("20000") int timeout)
     {}
@@ -61,4 +62,7 @@ public record Transform(@NotNull Request request, @NotNull Response response, @N
             retry = requireNonNullElseGet(retry, Retry::new);
         }
     }
+
+    public record MimeType(Map<String, String> mapping)
+    {}
 }

--- a/live-ingester/src/main/resources/application.yml
+++ b/live-ingester/src/main/resources/application.yml
@@ -34,6 +34,9 @@ alfresco:
     shared-file-store:
       host: http://localhost
       port: 8099
+    mime-type:
+      mapping:
+        '[*]': "application/pdf"
   filter:
     aspect:
       allow:


### PR DESCRIPTION
Adding empty configuration for mime type mappings. 
However, this configuration should allow to set up the mappings in following way:
``` yml
    mime-type:
      mapping:
        '[image/png]': "image/png"
        '[image/bmp]': "image/png"
        '[image/gif]': "image/png"
        '[image/raw]': "image/png"
        '[image/*]': "image/jpeg"
        '[*]': "application/pdf"
```
In the next PRs I will utilize this configuration to request transforms to mime types other than PDF (with support of exact matching, partial wildcards for subtypes and wildcards).