### PR TITLE
ACS-6905: Handling various mime type configurations for transforms.

### DIFF
--- a/distribution/src/main/resources/docker-compose/wiremock/hxinsight/__files/presigned-urls.json
+++ b/distribution/src/main/resources/docker-compose/wiremock/hxinsight/__files/presigned-urls.json
@@ -1,6 +1,6 @@
 [
   {
     "id": "12341234-1234-1234-1234-123412341234",
-    "url": "http://{{ systemValue type='ENVIRONMENT' key='AWS_HOST' }}:{{ systemValue type='ENVIRONMENT' key='AWS_PORT' }}/{{ systemValue type='ENVIRONMENT' key='AWS_S3_BUCKET_NAME' }}/dummy-{{ now format='HHmmssSSS' }}-{{ randomValue length=7 type='ALPHABETIC' }}.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240109T154539Z&X-Amz-SignedHeaders=content-type%3Bhost&X-Amz-Credential=test%2F20240109%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Expires=60&X-Amz-Signature=31cf819142af9946947f6447d18f624bbad7f69d78ab72959a6cbb0048550f3c"
+    "url": "http://{{ systemValue type='ENVIRONMENT' key='AWS_HOST' }}:{{ systemValue type='ENVIRONMENT' key='AWS_PORT' }}/{{ systemValue type='ENVIRONMENT' key='AWS_S3_BUCKET_NAME' }}/dummy-{{ now format='HHmmssSSS' }}-{{ randomValue length=7 type='ALPHABETIC' }}.bin?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240109T154539Z&X-Amz-SignedHeaders=content-type%3Bhost&X-Amz-Credential=test%2F20240109%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Expires=60&X-Amz-Signature=31cf819142af9946947f6447d18f624bbad7f69d78ab72959a6cbb0048550f3c"
   }
 ]

--- a/e2e-test/src/test/resources/wiremock/hxinsight/__files/pre-signed-url.json
+++ b/e2e-test/src/test/resources/wiremock/hxinsight/__files/pre-signed-url.json
@@ -1,4 +1,4 @@
 {
   "objectId": 1,
-  "preSignedUrl": "http://{{ systemValue type='ENVIRONMENT' key='AWS_HOST' }}:{{ systemValue type='ENVIRONMENT' key='AWS_PORT' }}/{{ systemValue type='ENVIRONMENT' key='AWS_S3_BUCKET_NAME' }}/dummy-{{ now format='HHmmssSSS' }}-{{ randomValue length=7 type='ALPHABETIC' }}.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240109T154539Z&X-Amz-SignedHeaders=content-type%3Bhost&X-Amz-Credential=test%2F20240109%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Expires=60&X-Amz-Signature=31cf819142af9946947f6447d18f624bbad7f69d78ab72959a6cbb0048550f3c"
+  "preSignedUrl": "http://{{ systemValue type='ENVIRONMENT' key='AWS_HOST' }}:{{ systemValue type='ENVIRONMENT' key='AWS_PORT' }}/{{ systemValue type='ENVIRONMENT' key='AWS_S3_BUCKET_NAME' }}/dummy-{{ now format='HHmmssSSS' }}-{{ randomValue length=7 type='ALPHABETIC' }}.bin?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240109T154539Z&X-Amz-SignedHeaders=content-type%3Bhost&X-Amz-Credential=test%2F20240109%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Expires=60&X-Amz-Signature=31cf819142af9946947f6447d18f624bbad7f69d78ab72959a6cbb0048550f3c"
 }

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/transform/response/ATSTransformResponseHandlerTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/transform/response/ATSTransformResponseHandlerTest.java
@@ -120,7 +120,8 @@ class ATSTransformResponseHandlerTest
 
         IngestContentCommand expectedCommand = new IngestContentCommand(
                 transformedFileId,
-                nodeId);
+                nodeId,
+                transformResponse.clientData().targetMimeType());
 
         doThrow(new LiveIngesterRuntimeException("Some exception")).when(ingestContentCommandHandler).handle(expectedCommand);
 
@@ -150,7 +151,8 @@ class ATSTransformResponseHandlerTest
 
         IngestContentCommand expectedCommand = new IngestContentCommand(
                 transformedFileId,
-                nodeId);
+                nodeId,
+                transformResponse.clientData().targetMimeType());
 
         doThrow(exception).when(ingestContentCommandHandler).handle(expectedCommand);
 
@@ -182,7 +184,8 @@ class ATSTransformResponseHandlerTest
 
         IngestContentCommand expectedCommand = new IngestContentCommand(
                 transformedFileId,
-                nodeId);
+                nodeId,
+                transformResponse.clientData().targetMimeType());
 
         doThrow(exception).when(ingestContentCommandHandler).handle(expectedCommand);
 

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/bulk_ingester/BulkIngesterEventIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/bulk_ingester/BulkIngesterEventIntegrationTest.java
@@ -28,9 +28,12 @@ package org.alfresco.hxi_connector.live_ingester.domain.usecase.e2e.bulk_ingeste
 import static org.alfresco.hxi_connector.live_ingester.util.ContainerSupport.REQUEST_ID_PLACEHOLDER;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
 
 import org.alfresco.hxi_connector.live_ingester.util.E2ETestBase;
 
+@SpringBootTest(properties = {"alfresco.transform.mime-type.mapping.[text/*]=application/pdf",
+        "logging.level.org.alfresco=DEBUG"})
 @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 public class BulkIngesterEventIntegrationTest extends E2ETestBase
 {

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/bulk_ingester/BulkIngesterEventMatchingContentMappingIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/bulk_ingester/BulkIngesterEventMatchingContentMappingIntegrationTest.java
@@ -33,13 +33,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import org.alfresco.hxi_connector.live_ingester.util.E2ETestBase;
 
-@SpringBootTest(properties = {"alfresco.transform.mime-type.mapping.[image/png]=image/png",
-        "alfresco.transform.mime-type.mapping.[image/bmp]=image/png",
-        "alfresco.transform.mime-type.mapping.[image/raw]=image/png",
-        "alfresco.transform.mime-type.mapping.[image/gif]=image/png",
-        "alfresco.transform.mime-type.mapping.[image/*]=image/jpeg",
-        "alfresco.transform.mime-type.mapping.[*]=application/pdf",
-        "logging.level.org.alfresco=DEBUG"})
+@SpringBootTest(properties = {"logging.level.org.alfresco=DEBUG"})
 @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 public class BulkIngesterEventMatchingContentMappingIntegrationTest extends E2ETestBase
 {
@@ -52,7 +46,7 @@ public class BulkIngesterEventMatchingContentMappingIntegrationTest extends E2ET
             "text/plain,application/pdf", "text/html,application/pdf"
     })
     void givenExactAndWildcardMimeTypeMappingForContentConfigured_whenContentWithMatchingTypeIngested_thenProcessWithTransformRequest(
-            String sourceMimeType, String targetMimeType)
+            String sourceMimeType, String expectedTargetMimeType)
     {
         // given
         containerSupport.prepareHxInsightToReturnSuccess();
@@ -93,10 +87,10 @@ public class BulkIngesterEventMatchingContentMappingIntegrationTest extends E2ET
                       "createdBy": {"value": "admin"},
                       "modifiedBy": {"value": "hr_user"},
                       "aspectsNames": {"value": ["cm:indexControl", "cm:auditable"]},
-                      "createdAt": {"value": "1308061016"},
+                      "createdAt": {"value": 1308061016},
                       "cm:name": {"value": "dashboard.xml"},
-                      "cm:isContentIndexed": {"value": "true"},
-                      "cm:isIndexed": {"value": "false"},
+                      "cm:isContentIndexed": {"value": true},
+                      "cm:isIndexed": {"value": false},
                       "cm:content": {
                         "file": {
                           "content-metadata": {
@@ -119,7 +113,7 @@ public class BulkIngesterEventMatchingContentMappingIntegrationTest extends E2ET
                     "clientData": "{\\"nodeRef\\":\\"37be157c-741c-4e51-b781-20d36e4e335a\\",\\"targetMimeType\\":\\"%s\\",\\"retryAttempt\\":0}",
                     "transformOptions": { "timeout":"20000" },
                     "replyQueue": "org.alfresco.hxinsight-connector.transform.response"
-                }""".formatted(REQUEST_ID_PLACEHOLDER, targetMimeType, targetMimeType);
+                }""".formatted(REQUEST_ID_PLACEHOLDER, expectedTargetMimeType, expectedTargetMimeType);
         containerSupport.verifyATSRequestReceived(expectedATSRequest);
 
     }

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/bulk_ingester/BulkIngesterEventMatchingContentMappingIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/bulk_ingester/BulkIngesterEventMatchingContentMappingIntegrationTest.java
@@ -33,7 +33,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import org.alfresco.hxi_connector.live_ingester.util.E2ETestBase;
 
-@SpringBootTest(properties = {"logging.level.org.alfresco=DEBUG"})
+@SpringBootTest(properties = {"alfresco.transform.mime-type.mapping.[text/*]=application/pdf",
+        "logging.level.org.alfresco=DEBUG"})
 @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 public class BulkIngesterEventMatchingContentMappingIntegrationTest extends E2ETestBase
 {

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/bulk_ingester/BulkIngesterEventMatchingContentMappingIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/bulk_ingester/BulkIngesterEventMatchingContentMappingIntegrationTest.java
@@ -1,0 +1,126 @@
+/*
+ * #%L
+ * Alfresco HX Insight Connector
+ * %%
+ * Copyright (C) 2023 - 2024 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.hxi_connector.live_ingester.domain.usecase.e2e.bulk_ingester;
+
+import static org.alfresco.hxi_connector.live_ingester.util.ContainerSupport.REQUEST_ID_PLACEHOLDER;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import org.alfresco.hxi_connector.live_ingester.util.E2ETestBase;
+
+@SpringBootTest(properties = {"alfresco.transform.mime-type.mapping.[image/png]=image/png",
+        "alfresco.transform.mime-type.mapping.[image/bmp]=image/png",
+        "alfresco.transform.mime-type.mapping.[image/raw]=image/png",
+        "alfresco.transform.mime-type.mapping.[image/gif]=image/png",
+        "alfresco.transform.mime-type.mapping.[image/*]=image/jpeg",
+        "alfresco.transform.mime-type.mapping.[*]=application/pdf",
+        "logging.level.org.alfresco=DEBUG"})
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+public class BulkIngesterEventMatchingContentMappingIntegrationTest extends E2ETestBase
+{
+
+    @ParameterizedTest
+    @CsvSource({
+            "image/gif,image/png", "image/bmp,image/png", "image/png,image/png", "image/raw,image/png",
+            "image/jpeg,image/jpeg", "image/heic,image/jpeg", "image/webp,image/jpeg",
+            "application/msword,application/pdf", "application/pdf,application/pdf",
+            "text/plain,application/pdf", "text/html,application/pdf"
+    })
+    void givenExactAndWildcardMimeTypeMappingForContentConfigured_whenContentWithMatchingTypeIngested_thenProcessWithTransformRequest(
+            String sourceMimeType, String targetMimeType)
+    {
+        // given
+        containerSupport.prepareHxInsightToReturnSuccess();
+
+        // when
+        String repoEvent = """
+                {
+                  "nodeId": "37be157c-741c-4e51-b781-20d36e4e335a",
+                  "contentInfo": {
+                    "contentSize": 330,
+                    "encoding": "ISO-8859-1",
+                    "mimetype": "%s"
+                  },
+                  "properties": {
+                    "cm:name": "dashboard.xml",
+                    "cm:isContentIndexed": true,
+                    "cm:isIndexed": false,
+                    "createdAt": 1308061016,
+                    "type": "cm:content",
+                    "createdBy": "admin",
+                    "modifiedBy": "hr_user",
+                    "aspectsNames": [
+                      "cm:indexControl",
+                      "cm:auditable"
+                    ]
+                  }
+                }""".formatted(sourceMimeType);
+        containerSupport.raiseBulkIngesterEvent(repoEvent);
+
+        // then
+        String expectedBody = """
+                [
+                  {
+                    "objectId" : "37be157c-741c-4e51-b781-20d36e4e335a",
+                    "eventType" : "create",
+                    "properties" : {
+                      "type": {"value": "cm:content"},
+                      "createdBy": {"value": "admin"},
+                      "modifiedBy": {"value": "hr_user"},
+                      "aspectsNames": {"value": ["cm:indexControl", "cm:auditable"]},
+                      "createdAt": {"value": "1308061016"},
+                      "cm:name": {"value": "dashboard.xml"},
+                      "cm:isContentIndexed": {"value": "true"},
+                      "cm:isIndexed": {"value": "false"},
+                      "cm:content": {
+                        "file": {
+                          "content-metadata": {
+                            "name": "dashboard.xml",
+                            "size": 330,
+                            "content-type": "%s"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]""".formatted(sourceMimeType);
+        containerSupport.expectHxIngestMessageReceived(expectedBody);
+
+        String expectedATSRequest = """
+                {
+                    "requestId": "%s",
+                    "nodeRef": "workspace://SpacesStore/37be157c-741c-4e51-b781-20d36e4e335a",
+                    "targetMediaType": "%s",
+                    "clientData": "{\\"nodeRef\\":\\"37be157c-741c-4e51-b781-20d36e4e335a\\",\\"targetMimeType\\":\\"%s\\",\\"retryAttempt\\":0}",
+                    "transformOptions": { "timeout":"20000" },
+                    "replyQueue": "org.alfresco.hxinsight-connector.transform.response"
+                }""".formatted(REQUEST_ID_PLACEHOLDER, targetMimeType, targetMimeType);
+        containerSupport.verifyATSRequestReceived(expectedATSRequest);
+
+    }
+}

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/bulk_ingester/BulkIngesterEventNonMatchingContentMappingIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/bulk_ingester/BulkIngesterEventNonMatchingContentMappingIntegrationTest.java
@@ -1,0 +1,108 @@
+/*
+ * #%L
+ * Alfresco HX Insight Connector
+ * %%
+ * Copyright (C) 2023 - 2024 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.hxi_connector.live_ingester.domain.usecase.e2e.bulk_ingester;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import org.alfresco.hxi_connector.live_ingester.util.E2ETestBase;
+
+@SpringBootTest(properties = {"alfresco.transform.mime-type.mapping.[image/png]=image/png",
+        "alfresco.transform.mime-type.mapping.[image/bmp]=image/png",
+        "alfresco.transform.mime-type.mapping.[image/raw]=image/png",
+        "alfresco.transform.mime-type.mapping.[image/gif]=image/png",
+        "alfresco.transform.mime-type.mapping.[image/*]=image/jpeg",
+        "alfresco.transform.mime-type.mapping.[application/*]=application/pdf",
+        "logging.level.org.alfresco=DEBUG"})
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+public class BulkIngesterEventNonMatchingContentMappingIntegrationTest extends E2ETestBase
+{
+
+    @ParameterizedTest
+    @ValueSource(strings = {"text/plain", "text/html", "text/richtext"})
+    void givenExactAndWildcardMimeTypeMappingForContentConfigured_whenContentWithNotMatchingTypeIngested_thenProcessWithoutTransformRequest(
+            String sourceMimeType)
+    {
+        // given
+        containerSupport.prepareHxInsightToReturnSuccess();
+
+        // when
+        String repoEvent = """
+                {
+                  "nodeId": "37be157c-741c-4e51-b781-20d36e4e335a",
+                  "contentInfo": {
+                    "contentSize": 330,
+                    "encoding": "ISO-8859-1",
+                    "mimetype": "%s"
+                  },
+                  "properties": {
+                    "cm:name": "dashboard.xml",
+                    "cm:isContentIndexed": true,
+                    "cm:isIndexed": false,
+                    "createdAt": 1308061016,
+                    "type": "cm:content",
+                    "createdBy": "admin",
+                    "modifiedBy": "hr_user",
+                    "aspectsNames": [
+                      "cm:indexControl",
+                      "cm:auditable"
+                    ]
+                  }
+                }""".formatted(sourceMimeType);
+        containerSupport.raiseBulkIngesterEvent(repoEvent);
+
+        // then
+        String expectedBody = """
+                [
+                  {
+                    "objectId" : "37be157c-741c-4e51-b781-20d36e4e335a",
+                    "eventType" : "create",
+                    "properties" : {
+                      "type": {"value": "cm:content"},
+                      "createdBy": {"value": "admin"},
+                      "modifiedBy": {"value": "hr_user"},
+                      "aspectsNames": {"value": ["cm:indexControl", "cm:auditable"]},
+                      "createdAt": {"value": "1308061016"},
+                      "cm:name": {"value": "dashboard.xml"},
+                      "cm:isContentIndexed": {"value": "true"},
+                      "cm:isIndexed": {"value": "false"},
+                      "cm:content": {
+                        "file": {
+                          "content-metadata": {
+                            "name": "dashboard.xml",
+                            "size": 330,
+                            "content-type": "%s"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]""".formatted(sourceMimeType);
+        containerSupport.expectHxIngestMessageReceived(expectedBody);
+        containerSupport.verifyNoATSRequestReceived(200);
+    }
+}

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/bulk_ingester/BulkIngesterEventNonMatchingContentMappingIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/bulk_ingester/BulkIngesterEventNonMatchingContentMappingIntegrationTest.java
@@ -31,19 +31,13 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import org.alfresco.hxi_connector.live_ingester.util.E2ETestBase;
 
-@SpringBootTest(properties = {"alfresco.transform.mime-type.mapping.[image/png]=image/png",
-        "alfresco.transform.mime-type.mapping.[image/bmp]=image/png",
-        "alfresco.transform.mime-type.mapping.[image/raw]=image/png",
-        "alfresco.transform.mime-type.mapping.[image/gif]=image/png",
-        "alfresco.transform.mime-type.mapping.[image/*]=image/jpeg",
-        "alfresco.transform.mime-type.mapping.[application/*]=application/pdf",
-        "logging.level.org.alfresco=DEBUG"})
+@SpringBootTest(properties = {"logging.level.org.alfresco=DEBUG"})
 @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 public class BulkIngesterEventNonMatchingContentMappingIntegrationTest extends E2ETestBase
 {
 
     @ParameterizedTest
-    @ValueSource(strings = {"text/plain", "text/html", "text/richtext"})
+    @ValueSource(strings = {"nonmatchingtext/plain", "nonmatchingtext/html", "nonmatchingtext/richtext"})
     void givenExactAndWildcardMimeTypeMappingForContentConfigured_whenContentWithNotMatchingTypeIngested_thenProcessWithoutTransformRequest(
             String sourceMimeType)
     {
@@ -86,10 +80,10 @@ public class BulkIngesterEventNonMatchingContentMappingIntegrationTest extends E
                       "createdBy": {"value": "admin"},
                       "modifiedBy": {"value": "hr_user"},
                       "aspectsNames": {"value": ["cm:indexControl", "cm:auditable"]},
-                      "createdAt": {"value": "1308061016"},
+                      "createdAt": {"value": 1308061016},
                       "cm:name": {"value": "dashboard.xml"},
-                      "cm:isContentIndexed": {"value": "true"},
-                      "cm:isIndexed": {"value": "false"},
+                      "cm:isContentIndexed": {"value": true},
+                      "cm:isIndexed": {"value": false},
                       "cm:content": {
                         "file": {
                           "content-metadata": {

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/bulk_ingester/BulkIngesterEventNonMatchingContentMappingIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/bulk_ingester/BulkIngesterEventNonMatchingContentMappingIntegrationTest.java
@@ -37,7 +37,7 @@ public class BulkIngesterEventNonMatchingContentMappingIntegrationTest extends E
 {
 
     @ParameterizedTest
-    @ValueSource(strings = {"nonmatchingtext/plain", "nonmatchingtext/html", "nonmatchingtext/richtext"})
+    @ValueSource(strings = {"text/plain", "text/html", "text/richtext"})
     void givenExactAndWildcardMimeTypeMappingForContentConfigured_whenContentWithNotMatchingTypeIngested_thenProcessWithoutTransformRequest(
             String sourceMimeType)
     {

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/MatchingContentMappingRequestIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/MatchingContentMappingRequestIntegrationTest.java
@@ -33,7 +33,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import org.alfresco.hxi_connector.live_ingester.util.E2ETestBase;
 
-@SpringBootTest(properties = {"logging.level.org.alfresco=DEBUG"})
+@SpringBootTest(properties = {"alfresco.transform.mime-type.mapping.[text/*]=application/pdf",
+        "logging.level.org.alfresco=DEBUG"})
 @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 public class MatchingContentMappingRequestIntegrationTest extends E2ETestBase
 {

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/MatchingContentMappingRequestIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/MatchingContentMappingRequestIntegrationTest.java
@@ -33,13 +33,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import org.alfresco.hxi_connector.live_ingester.util.E2ETestBase;
 
-@SpringBootTest(properties = {"alfresco.transform.mime-type.mapping.[image/png]=image/png",
-        "alfresco.transform.mime-type.mapping.[image/bmp]=image/png",
-        "alfresco.transform.mime-type.mapping.[image/raw]=image/png",
-        "alfresco.transform.mime-type.mapping.[image/gif]=image/png",
-        "alfresco.transform.mime-type.mapping.[image/*]=image/jpeg",
-        "alfresco.transform.mime-type.mapping.[*]=application/pdf",
-        "logging.level.org.alfresco=DEBUG"})
+@SpringBootTest(properties = {"logging.level.org.alfresco=DEBUG"})
 @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 public class MatchingContentMappingRequestIntegrationTest extends E2ETestBase
 {
@@ -51,7 +45,7 @@ public class MatchingContentMappingRequestIntegrationTest extends E2ETestBase
             "text/html,application/pdf"
     })
     void givenExactAndWildcardMimeTypeMappingForContentConfigured_whenContentWithMatchingTypeIngested_thenProcessWithTransformRequest(
-            String sourceMimeType, String targetMimeType)
+            String sourceMimeType, String expectedTargetMimeType)
     {
         // given
         containerSupport.prepareHxInsightToReturnSuccess();
@@ -111,8 +105,8 @@ public class MatchingContentMappingRequestIntegrationTest extends E2ETestBase
                     "objectId": "d71dd823-01c7-477c-8490-04cb0e826e61",
                     "eventType": "create",
                     "properties": {
-                      "cm:autoVersion": {"value": "true"},
-                      "createdAt": {"value": "1611227655695"},
+                      "cm:autoVersion": {"value": true},
+                      "createdAt": {"value": 1611227655695},
                       "cm:versionType": {"value": "MAJOR"},
                       "aspectsNames": {"value": ["cm:versionable", "cm:auditable"]},
                       "cm:name": {"value": "purchase-order-scan.bmp"},
@@ -141,7 +135,7 @@ public class MatchingContentMappingRequestIntegrationTest extends E2ETestBase
                     "clientData": "{\\"nodeRef\\":\\"d71dd823-01c7-477c-8490-04cb0e826e61\\",\\"targetMimeType\\":\\"%s\\",\\"retryAttempt\\":0}",
                     "transformOptions": { "timeout":"20000" },
                     "replyQueue": "org.alfresco.hxinsight-connector.transform.response"
-                }""".formatted(REQUEST_ID_PLACEHOLDER, targetMimeType, targetMimeType);
+                }""".formatted(REQUEST_ID_PLACEHOLDER, expectedTargetMimeType, expectedTargetMimeType);
         containerSupport.verifyATSRequestReceived(expectedATSRequest);
     }
 }

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/MatchingContentMappingRequestIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/MatchingContentMappingRequestIntegrationTest.java
@@ -1,0 +1,147 @@
+/*
+ * #%L
+ * Alfresco HX Insight Connector
+ * %%
+ * Copyright (C) 2023 - 2024 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.hxi_connector.live_ingester.domain.usecase.e2e.repository;
+
+import static org.alfresco.hxi_connector.live_ingester.util.ContainerSupport.REQUEST_ID_PLACEHOLDER;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import org.alfresco.hxi_connector.live_ingester.util.E2ETestBase;
+
+@SpringBootTest(properties = {"alfresco.transform.mime-type.mapping.[image/png]=image/png",
+        "alfresco.transform.mime-type.mapping.[image/bmp]=image/png",
+        "alfresco.transform.mime-type.mapping.[image/raw]=image/png",
+        "alfresco.transform.mime-type.mapping.[image/gif]=image/png",
+        "alfresco.transform.mime-type.mapping.[image/*]=image/jpeg",
+        "alfresco.transform.mime-type.mapping.[*]=application/pdf",
+        "logging.level.org.alfresco=DEBUG"})
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+public class MatchingContentMappingRequestIntegrationTest extends E2ETestBase
+{
+
+    @ParameterizedTest
+    @CsvSource({"image/gif,image/png", "image/bmp,image/png", "image/png,image/png", "image/raw,image/png",
+            "image/jpeg,image/jpeg", "image/heic,image/jpeg", "image/webp,image/jpeg",
+            "application/msword,application/pdf", "application/pdf,application/pdf", "text/plain,application/pdf",
+            "text/html,application/pdf"
+    })
+    void givenExactAndWildcardMimeTypeMappingForContentConfigured_whenContentWithMatchingTypeIngested_thenProcessWithTransformRequest(
+            String sourceMimeType, String targetMimeType)
+    {
+        // given
+        containerSupport.prepareHxInsightToReturnSuccess();
+
+        // when
+        String repoEvent = """
+                {
+                  "specversion": "1.0",
+                  "type": "org.alfresco.event.node.Created",
+                  "id": "368818d9-eaeq-4b8b-8eab-e050253d7f61",
+                  "source": "/08d9b620-14de-4247-8f33-360988d3b191",
+                  "time": "2021-01-21T11:14:16.42372Z",
+                  "dataschema": "https://api.alfresco.com/schema/event/repo/v1/nodeCreated",
+                  "datacontenttype": "application/json",
+                  "data": {
+                    "eventGroupId": "4004ca99-9f2e-400d-9d80-8f840e223581",
+                    "resource": {
+                      "@type": "NodeResource",
+                      "id": "d71dd823-01c7-477c-8490-04cb0e826e61",
+                      "primaryHierarchy": [ "5f355d16-f824-4173-bf4b-b1ec37ef5549", "93f7edf5-e4d8-4749-9b4c-e45097e2e19d" ],
+                      "name": "purchase-order-scan.bmp",
+                      "nodeType": "cm:content",
+                      "createdByUser": {
+                        "id": "admin",
+                        "displayName": "Administrator"
+                      },
+                      "createdAt": "2021-01-21T11:14:15.695Z",
+                      "modifiedByUser": {
+                        "id": "admin",
+                        "displayName": "Administrator"
+                      },
+                      "modifiedAt": "2021-01-21T11:14:15.695Z",
+                      "content": {
+                        "mimeType": "%s",
+                        "sizeInBytes": 531152,
+                        "encoding": "UTF-8"
+                      },
+                      "properties": {
+                        "cm:autoVersion": true,
+                        "cm:versionType": "MAJOR",
+                        "cm:taggable": null
+                      },
+                      "aspectNames": [ "cm:versionable", "cm:auditable" ],
+                      "isFolder": false,
+                      "isFile": true
+                    },
+                    "resourceReaderAuthorities": [ "GROUP_EVERYONE" ],
+                    "resourceDeniedAuthorities": []
+                  }
+                }""".formatted(sourceMimeType);
+        containerSupport.raiseRepoEvent(repoEvent);
+
+        // then
+        String expectedBody = """
+                [
+                  {
+                    "objectId": "d71dd823-01c7-477c-8490-04cb0e826e61",
+                    "eventType": "create",
+                    "properties": {
+                      "cm:autoVersion": {"value": "true"},
+                      "createdAt": {"value": "1611227655695"},
+                      "cm:versionType": {"value": "MAJOR"},
+                      "aspectsNames": {"value": ["cm:versionable", "cm:auditable"]},
+                      "cm:name": {"value": "purchase-order-scan.bmp"},
+                      "type": {"value": "cm:content"},
+                      "createdBy": {"value": "admin"},
+                      "modifiedBy": {"value": "admin"},
+                      "cm:content": {
+                        "file": {
+                          "content-metadata": {
+                            "size": 531152,
+                            "name": "purchase-order-scan.bmp",
+                            "content-type": "%s"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]""".formatted(sourceMimeType);
+        containerSupport.expectHxIngestMessageReceived(expectedBody);
+
+        String expectedATSRequest = """
+                {
+                    "requestId": "%s",
+                    "nodeRef": "workspace://SpacesStore/d71dd823-01c7-477c-8490-04cb0e826e61",
+                    "targetMediaType": "%s",
+                    "clientData": "{\\"nodeRef\\":\\"d71dd823-01c7-477c-8490-04cb0e826e61\\",\\"targetMimeType\\":\\"%s\\",\\"retryAttempt\\":0}",
+                    "transformOptions": { "timeout":"20000" },
+                    "replyQueue": "org.alfresco.hxinsight-connector.transform.response"
+                }""".formatted(REQUEST_ID_PLACEHOLDER, targetMimeType, targetMimeType);
+        containerSupport.verifyATSRequestReceived(expectedATSRequest);
+    }
+}

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/NonMatchingContentMappingRequestIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/NonMatchingContentMappingRequestIntegrationTest.java
@@ -37,7 +37,7 @@ class NonMatchingContentMappingRequestIntegrationTest extends E2ETestBase
 {
 
     @ParameterizedTest
-    @ValueSource(strings = {"nonmatchingtext/plain", "nonmatchingtext/html", "nonmatchingtext/richtext"})
+    @ValueSource(strings = {"text/plain", "text/html", "text/richtext"})
     void givenExactAndWildcardMimeTypeMappingForContentConfigured_whenContentWithNotMatchingTypeIngested_thenProcessWithoutTransformRequest(
             String sourceMimeType)
     {

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/NonMatchingContentMappingRequestIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/NonMatchingContentMappingRequestIntegrationTest.java
@@ -31,19 +31,13 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import org.alfresco.hxi_connector.live_ingester.util.E2ETestBase;
 
-@SpringBootTest(properties = {"alfresco.transform.mime-type.mapping.[image/png]=image/png",
-        "alfresco.transform.mime-type.mapping.[image/bmp]=image/png",
-        "alfresco.transform.mime-type.mapping.[image/raw]=image/png",
-        "alfresco.transform.mime-type.mapping.[image/gif]=image/png",
-        "alfresco.transform.mime-type.mapping.[image/*]=image/jpeg",
-        "alfresco.transform.mime-type.mapping.[application/*]=application/pdf",
-        "logging.level.org.alfresco=DEBUG"})
+@SpringBootTest(properties = {"logging.level.org.alfresco=DEBUG"})
 @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 class NonMatchingContentMappingRequestIntegrationTest extends E2ETestBase
 {
 
     @ParameterizedTest
-    @ValueSource(strings = {"text/plain", "text/html", "text/richtext"})
+    @ValueSource(strings = {"nonmatchingtext/plain", "nonmatchingtext/html", "nonmatchingtext/richtext"})
     void givenExactAndWildcardMimeTypeMappingForContentConfigured_whenContentWithNotMatchingTypeIngested_thenProcessWithoutTransformRequest(
             String sourceMimeType)
     {
@@ -105,8 +99,8 @@ class NonMatchingContentMappingRequestIntegrationTest extends E2ETestBase
                     "objectId": "d71dd823-01c7-477c-8490-04cb0e826e61",
                     "eventType": "create",
                     "properties": {
-                      "cm:autoVersion": {"value": "true"},
-                      "createdAt": {"value": "1611227655695"},
+                      "cm:autoVersion": {"value": true},
+                      "createdAt": {"value": 1611227655695},
                       "cm:versionType": {"value": "MAJOR"},
                       "aspectsNames": {"value": ["cm:versionable", "cm:auditable"]},
                       "cm:name": {"value": "purchase-order-scan.bmp"},

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/NonMatchingContentMappingRequestIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/NonMatchingContentMappingRequestIntegrationTest.java
@@ -1,0 +1,132 @@
+/*-
+ * #%L
+ * Alfresco HX Insight Connector
+ * %%
+ * Copyright (C) 2023 - 2024 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.hxi_connector.live_ingester.domain.usecase.e2e.repository;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import org.alfresco.hxi_connector.live_ingester.util.E2ETestBase;
+
+@SpringBootTest(properties = {"alfresco.transform.mime-type.mapping.[image/png]=image/png",
+        "alfresco.transform.mime-type.mapping.[image/bmp]=image/png",
+        "alfresco.transform.mime-type.mapping.[image/raw]=image/png",
+        "alfresco.transform.mime-type.mapping.[image/gif]=image/png",
+        "alfresco.transform.mime-type.mapping.[image/*]=image/jpeg",
+        "alfresco.transform.mime-type.mapping.[application/*]=application/pdf",
+        "logging.level.org.alfresco=DEBUG"})
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+class NonMatchingContentMappingRequestIntegrationTest extends E2ETestBase
+{
+
+    @ParameterizedTest
+    @ValueSource(strings = {"text/plain", "text/html", "text/richtext"})
+    void givenExactAndWildcardMimeTypeMappingForContentConfigured_whenContentWithNotMatchingTypeIngested_thenProcessWithoutTransformRequest(
+            String sourceMimeType)
+    {
+        // given
+        containerSupport.prepareHxInsightToReturnSuccess();
+
+        // when
+        String repoEvent = """
+                {
+                  "specversion": "1.0",
+                  "type": "org.alfresco.event.node.Created",
+                  "id": "368818d9-eaeq-4b8b-8eab-e050253d7f61",
+                  "source": "/08d9b620-14de-4247-8f33-360988d3b191",
+                  "time": "2021-01-21T11:14:16.42372Z",
+                  "dataschema": "https://api.alfresco.com/schema/event/repo/v1/nodeCreated",
+                  "datacontenttype": "application/json",
+                  "data": {
+                    "eventGroupId": "4004ca99-9f2e-400d-9d80-8f840e223581",
+                    "resource": {
+                      "@type": "NodeResource",
+                      "id": "d71dd823-01c7-477c-8490-04cb0e826e61",
+                      "primaryHierarchy": [ "5f355d16-f824-4173-bf4b-b1ec37ef5549", "93f7edf5-e4d8-4749-9b4c-e45097e2e19d" ],
+                      "name": "purchase-order-scan.bmp",
+                      "nodeType": "cm:content",
+                      "createdByUser": {
+                        "id": "admin",
+                        "displayName": "Administrator"
+                      },
+                      "createdAt": "2021-01-21T11:14:15.695Z",
+                      "modifiedByUser": {
+                        "id": "admin",
+                        "displayName": "Administrator"
+                      },
+                      "modifiedAt": "2021-01-21T11:14:15.695Z",
+                      "content": {
+                        "mimeType": "%s",
+                        "sizeInBytes": 531152,
+                        "encoding": "UTF-8"
+                      },
+                      "properties": {
+                        "cm:autoVersion": true,
+                        "cm:versionType": "MAJOR",
+                        "cm:taggable": null
+                      },
+                      "aspectNames": [ "cm:versionable", "cm:auditable" ],
+                      "isFolder": false,
+                      "isFile": true
+                    },
+                    "resourceReaderAuthorities": [ "GROUP_EVERYONE" ],
+                    "resourceDeniedAuthorities": []
+                  }
+                }""".formatted(sourceMimeType);
+        containerSupport.raiseRepoEvent(repoEvent);
+
+        // then
+        String expectedBody = """
+                [
+                  {
+                    "objectId": "d71dd823-01c7-477c-8490-04cb0e826e61",
+                    "eventType": "create",
+                    "properties": {
+                      "cm:autoVersion": {"value": "true"},
+                      "createdAt": {"value": "1611227655695"},
+                      "cm:versionType": {"value": "MAJOR"},
+                      "aspectsNames": {"value": ["cm:versionable", "cm:auditable"]},
+                      "cm:name": {"value": "purchase-order-scan.bmp"},
+                      "type": {"value": "cm:content"},
+                      "createdBy": {"value": "admin"},
+                      "modifiedBy": {"value": "admin"},
+                      "cm:content": {
+                        "file": {
+                          "content-metadata": {
+                            "size": 531152,
+                            "name": "purchase-order-scan.bmp",
+                            "content-type": "%s"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]""".formatted(sourceMimeType);
+        containerSupport.expectHxIngestMessageReceived(expectedBody);
+
+        containerSupport.verifyNoATSRequestReceived(200);
+    }
+}

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/util/ContainerSupport.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/util/ContainerSupport.java
@@ -200,6 +200,12 @@ public class ContainerSupport
         assertEquals(expectedMap, receivedMap);
     }
 
+    @SneakyThrows
+    public void verifyNoATSRequestReceived(long timeoutMillis)
+    {
+        assertThat(atsConsumer.receive(timeoutMillis)).isNull();
+    }
+
     public void clearATSQueue()
     {
         while (receiveATSTextMessage() != null)

--- a/live-ingester/src/integration-test/resources/application-test.yml
+++ b/live-ingester/src/integration-test/resources/application-test.yml
@@ -11,6 +11,15 @@ alfresco:
     shared-file-store:
       retry:
         initial-delay: 0
+    mime-type:
+      mapping:
+        '[image/png]': "image/png"
+        '[image/bmp]': "image/png"
+        '[image/gif]': "image/png"
+        '[image/raw]': "image/png"
+        '[image/tiff]': "image/png"
+        '[image/*]': "image/jpeg"
+        '[application/*]': "application/pdf"
 hyland-experience:
   authentication:
     retry:

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/config/properties/Transform.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/config/properties/Transform.java
@@ -27,16 +27,28 @@ package org.alfresco.hxi_connector.live_ingester.adapters.config.properties;
 
 import static java.util.Objects.requireNonNullElseGet;
 
+import java.util.Collections;
 import java.util.Map;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
 import org.springframework.boot.context.properties.bind.DefaultValue;
 
-public record Transform(@NotNull Request request, @NotNull Response response, @NotNull SharedFileStore sharedFileStore, @NotNull MimeType mimeType)
+public record Transform(@NotNull Request request, @NotNull Response response, @NotNull SharedFileStore sharedFileStore, MimeType mimeType)
 {
+
+    @ConstructorBinding
+    public Transform(@NotNull Request request, @NotNull Response response, @NotNull SharedFileStore sharedFileStore, MimeType mimeType)
+    {
+        this.request = request;
+        this.response = response;
+        this.sharedFileStore = sharedFileStore;
+        this.mimeType = mimeType != null ? mimeType : new MimeType(Collections.emptyMap());
+    }
+
     public record Request(@NotBlank String endpoint, @Positive @DefaultValue("20000") int timeout)
     {}
 

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/hx_insight/storage/connector/HttpFileUploader.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/hx_insight/storage/connector/HttpFileUploader.java
@@ -111,7 +111,7 @@ public class HttpFileUploader extends RouteBuilder implements FileUploader
                     .withHeaders(headers)
                     .withBody(fileData)
                     .request();
-            log.atDebug().log("Upload :: PDF rendition of the node: {} successfully uploaded to pre-signed URL: {}", nodeId, fileUploadRequest.storageLocation().getPath());
+            log.atDebug().log("Upload :: {} rendition of the node: {} successfully uploaded to pre-signed URL: {}", fileUploadRequest.contentType(), nodeId, fileUploadRequest.storageLocation().getPath());
         }
         catch (Exception e)
         {

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/mapper/MimeTypeMapper.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/mapper/MimeTypeMapper.java
@@ -28,7 +28,7 @@ package org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.m
 import java.util.Map;
 
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
@@ -52,11 +52,7 @@ public class MimeTypeMapper
 
     public String mapMimeType(String inputType)
     {
-        Map<String, String> mappings = MapUtils.emptyIfNull(integrationProperties.alfresco().transform().mimeType().mapping());
-        if (mappings.isEmpty())
-        {
-            mappings = DEFAULT_MIME_TYPES;
-        }
+        final Map<String, String> mappings = ObjectUtils.defaultIfNull(integrationProperties.alfresco().transform().mimeType().mapping(), DEFAULT_MIME_TYPES);
         return mappings.getOrDefault(inputType, determineWildcardMapping(inputType, mappings));
     }
 

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/mapper/MimeTypeMapper.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/mapper/MimeTypeMapper.java
@@ -1,0 +1,80 @@
+/*-
+ * #%L
+ * Alfresco HX Insight Connector
+ * %%
+ * Copyright (C) 2023 - 2024 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.mapper;
+
+import java.util.Map;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+import org.alfresco.hxi_connector.live_ingester.adapters.config.IntegrationProperties;
+
+@Component
+@RequiredArgsConstructor
+public class MimeTypeMapper
+{
+
+    public static String EMPTY_MIME_TYPE = "";
+    static final String DEFAULT_MIME_TYPE = "application/pdf";
+    private final IntegrationProperties integrationProperties;
+
+    public String mapMimeType(String inputType)
+    {
+        Map<String, String> mappings = MapUtils.emptyIfNull(integrationProperties.alfresco().transform().mimeType().mapping());
+        if (mappings.isEmpty())
+        {
+            return DEFAULT_MIME_TYPE;
+        }
+        return mappings.getOrDefault(inputType, determineWildcardMapping(inputType, mappings));
+    }
+
+    private String determineWildcardMapping(String inputType, Map<String, String> mappings)
+    {
+        for (Map.Entry<String, String> mapping : mappings.entrySet())
+        {
+            if (mapping.getKey().endsWith("/*"))
+            {
+                if (getType(inputType).equals(getType(mapping.getKey())))
+                {
+                    return StringUtils.defaultIfBlank(mapping.getValue(), EMPTY_MIME_TYPE);
+                }
+            }
+        }
+        return mappings.entrySet().stream()
+                .filter(mapping -> mapping.getKey().equals("*"))
+                .findFirst()
+                .map(Map.Entry::getValue)
+                .orElse(EMPTY_MIME_TYPE);
+    }
+
+    private static String getType(String inputType)
+    {
+        return inputType.split("/")[0];
+    }
+
+}

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/mapper/MimeTypeMapper.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/mapper/MimeTypeMapper.java
@@ -40,7 +40,13 @@ public class MimeTypeMapper
 {
 
     public static final String EMPTY_MIME_TYPE = "";
-    static final String DEFAULT_MIME_TYPE = "application/pdf";
+    static final Map<String, String> DEFAULT_MIME_TYPES = Map.of("image/png", "image/png",
+            "image/bmp", "image/png",
+            "image/tiff", "image/png",
+            "image/gif", "image/png",
+            "image/*", "image/jpg",
+            "application/*", "application/pdf",
+            "text/*", "application/pdf");
     private final IntegrationProperties integrationProperties;
 
     public String mapMimeType(String inputType)
@@ -48,7 +54,7 @@ public class MimeTypeMapper
         Map<String, String> mappings = MapUtils.emptyIfNull(integrationProperties.alfresco().transform().mimeType().mapping());
         if (mappings.isEmpty())
         {
-            return DEFAULT_MIME_TYPE;
+            mappings = DEFAULT_MIME_TYPES;
         }
         return mappings.getOrDefault(inputType, determineWildcardMapping(inputType, mappings));
     }
@@ -69,7 +75,7 @@ public class MimeTypeMapper
                 .orElse(EMPTY_MIME_TYPE);
     }
 
-    private static String getType(String inputType)
+    static String getType(String inputType)
     {
         return inputType.split("/")[0];
     }

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/mapper/MimeTypeMapper.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/mapper/MimeTypeMapper.java
@@ -44,6 +44,7 @@ public class MimeTypeMapper
             "image/bmp", "image/png",
             "image/tiff", "image/png",
             "image/gif", "image/png",
+            "image/raw", "image/png",
             "image/*", "image/jpg",
             "application/*", "application/pdf",
             "text/*", "application/pdf");

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/mapper/MimeTypeMapper.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/mapper/MimeTypeMapper.java
@@ -39,7 +39,7 @@ import org.alfresco.hxi_connector.live_ingester.adapters.config.IntegrationPrope
 public class MimeTypeMapper
 {
 
-    public static String EMPTY_MIME_TYPE = "";
+    public static final String EMPTY_MIME_TYPE = "";
     static final String DEFAULT_MIME_TYPE = "application/pdf";
     private final IntegrationProperties integrationProperties;
 
@@ -57,12 +57,9 @@ public class MimeTypeMapper
     {
         for (Map.Entry<String, String> mapping : mappings.entrySet())
         {
-            if (mapping.getKey().endsWith("/*"))
+            if (mapping.getKey().endsWith("/*") && getType(inputType).equals(getType(mapping.getKey())))
             {
-                if (getType(inputType).equals(getType(mapping.getKey())))
-                {
-                    return StringUtils.defaultIfBlank(mapping.getValue(), EMPTY_MIME_TYPE);
-                }
+                return StringUtils.defaultIfBlank(mapping.getValue(), EMPTY_MIME_TYPE);
             }
         }
         return mappings.entrySet().stream()

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/mapper/RepoEventMapper.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/mapper/RepoEventMapper.java
@@ -51,12 +51,15 @@ import org.alfresco.repo.event.v1.model.RepoEvent;
 public class RepoEventMapper
 {
     private final PropertiesMapper propertiesMapper;
+    private final MimeTypeMapper mimeTypeMapper;
 
     public TriggerContentIngestionCommand mapToIngestContentCommand(RepoEvent<DataAttributes<NodeResource>> event)
     {
         ensureThat(isEventTypeCreated(event) || isEventTypeUpdated(event), "Unsupported event type");
 
-        return new TriggerContentIngestionCommand(event.getData().getResource().getId());
+        final NodeResource resource = event.getData().getResource();
+        String mimeType = mimeTypeMapper.mapMimeType(resource.getContent().getMimeType());
+        return new TriggerContentIngestionCommand(resource.getId(), mimeType);
     }
 
     public IngestNodeCommand mapToIngestNodeCommand(RepoEvent<DataAttributes<NodeResource>> event)

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/transform/response/ATSTransformResponseHandler.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/transform/response/ATSTransformResponseHandler.java
@@ -91,7 +91,7 @@ public class ATSTransformResponseHandler extends RouteBuilder
             return;
         }
 
-        IngestContentCommand command = new IngestContentCommand(transformResponse.targetReference(), transformResponse.clientData().nodeRef());
+        IngestContentCommand command = new IngestContentCommand(transformResponse.targetReference(), transformResponse.clientData().nodeRef(), transformResponse.clientData().targetMimeType());
 
         ingestContentCommandHandler.handle(command);
     }

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/content/IngestContentCommand.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/content/IngestContentCommand.java
@@ -27,5 +27,6 @@ package org.alfresco.hxi_connector.live_ingester.domain.usecase.content;
 
 public record IngestContentCommand(
         String transformedFileId,
-        String nodeId)
+        String nodeId,
+        String mimeType)
 {}

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/content/IngestContentCommandHandler.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/content/IngestContentCommandHandler.java
@@ -53,8 +53,6 @@ import org.alfresco.hxi_connector.live_ingester.domain.usecase.metadata.model.Pr
 @RequiredArgsConstructor
 public class IngestContentCommandHandler
 {
-    private static final String PDF_MIMETYPE = "application/pdf";
-
     private final TransformRequester transformRequester;
     private final IngestNodeCommandHandler ingestNodeCommandHandler;
     private final TransformEngineFileStorage transformEngineFileStorage;
@@ -76,7 +74,7 @@ public class IngestContentCommandHandler
 
         log.atDebug().log("Transform :: Downloaded from SFS content of node: {} in file with ID: {}", nodeId, fileId);
 
-        IngestContentResponse ingestContentResponse = ingestionEngineStorageClient.upload(downloadedFile, PDF_MIMETYPE, nodeId);
+        IngestContentResponse ingestContentResponse = ingestionEngineStorageClient.upload(downloadedFile, command.mimeType(), nodeId);
 
         Set<PropertyDelta<?>> properties = Set.of(
                 contentPropertyUpdated(CONTENT_PROPERTY, ingestContentResponse.transferId(), ingestContentResponse.mimeType()));

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/content/IngestContentCommandHandler.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/content/IngestContentCommandHandler.java
@@ -62,7 +62,7 @@ public class IngestContentCommandHandler
 
     public void handle(TriggerContentIngestionCommand command)
     {
-        TransformRequest transformRequest = new TransformRequest(command.nodeId(), PDF_MIMETYPE);
+        TransformRequest transformRequest = new TransformRequest(command.nodeId(), command.mimeType());
         transformRequester.requestTransform(transformRequest);
     }
 

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/content/TriggerContentIngestionCommand.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/content/TriggerContentIngestionCommand.java
@@ -28,7 +28,7 @@ package org.alfresco.hxi_connector.live_ingester.domain.usecase.content;
 
 import static org.alfresco.hxi_connector.live_ingester.domain.utils.EnsureUtils.ensureNotBlank;
 
-public record TriggerContentIngestionCommand(String nodeId)
+public record TriggerContentIngestionCommand(String nodeId, String mimeType)
 {
     public TriggerContentIngestionCommand
     {

--- a/live-ingester/src/main/resources/application.yml
+++ b/live-ingester/src/main/resources/application.yml
@@ -36,16 +36,6 @@ alfresco:
     shared-file-store:
       host: http://localhost
       port: 8099
-    mime-type:
-      mapping:
-        '[image/png]': "image/png"
-        '[image/bmp]': "image/png"
-        '[image/gif]': "image/png"
-        '[image/raw]': "image/png"
-        '[image/tiff]': "image/png"
-        '[image/*]': "image/jpeg"
-        '[text/*]': "application/pdf"
-        '[application/*]': "application/pdf"
   filter:
     aspect:
       allow:

--- a/live-ingester/src/main/resources/application.yml
+++ b/live-ingester/src/main/resources/application.yml
@@ -34,6 +34,16 @@ alfresco:
     shared-file-store:
       host: http://localhost
       port: 8099
+    mime-type:
+      mapping:
+        '[image/png]': "image/png"
+        '[image/bmp]': "image/png"
+        '[image/gif]': "image/png"
+        '[image/raw]': "image/png"
+        '[image/tiff]': "image/png"
+        '[image/*]': "image/jpeg"
+        '[text/*]': "application/pdf"
+        '[application/*]': "application/pdf"
   filter:
     aspect:
       allow:

--- a/live-ingester/src/main/resources/application.yml
+++ b/live-ingester/src/main/resources/application.yml
@@ -34,7 +34,6 @@ alfresco:
     shared-file-store:
       host: http://localhost
       port: 8099
-    mime-type:
   filter:
     aspect:
       allow:

--- a/live-ingester/src/main/resources/application.yml
+++ b/live-ingester/src/main/resources/application.yml
@@ -35,8 +35,6 @@ alfresco:
       host: http://localhost
       port: 8099
     mime-type:
-      mapping:
-        '[*]': "application/pdf"
   filter:
     aspect:
       allow:

--- a/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/mapper/MimeTypeMapperTest.java
+++ b/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/mapper/MimeTypeMapperTest.java
@@ -28,10 +28,13 @@ package org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.m
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 
-import static org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.mapper.MimeTypeMapper.DEFAULT_MIME_TYPE;
+import static org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.mapper.MimeTypeMapper.DEFAULT_MIME_TYPES;
+import static org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.mapper.MimeTypeMapper.EMPTY_MIME_TYPE;
+import static org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.mapper.MimeTypeMapper.getType;
 
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -76,7 +79,7 @@ class MimeTypeMapperTest
         // when
         String resultMimeType = objectUnderTest.mapMimeType(sourceMimeType);
         // then
-        assertEquals(DEFAULT_MIME_TYPE, resultMimeType);
+        assertEquals(DEFAULT_MIME_TYPES.getOrDefault(sourceMimeType, getWildcardMappingFromDefault(sourceMimeType)), resultMimeType);
     }
 
     @ParameterizedTest
@@ -101,7 +104,7 @@ class MimeTypeMapperTest
         // when
         String resultMimeType = objectUnderTest.mapMimeType(sourceMimeType);
         // then
-        assertEquals(MimeTypeMapper.EMPTY_MIME_TYPE, resultMimeType);
+        assertEquals(EMPTY_MIME_TYPE, resultMimeType);
     }
 
     @ParameterizedTest
@@ -147,5 +150,22 @@ class MimeTypeMapperTest
         String resultMimeType = objectUnderTest.mapMimeType(sourceMimeType);
         // when
         assertEquals(targetMimeType, resultMimeType);
+    }
+
+    private String getWildcardMappingFromDefault(String inputType)
+    {
+
+        for (Map.Entry<String, String> mapping : DEFAULT_MIME_TYPES.entrySet())
+        {
+            if (mapping.getKey().endsWith("/*") && getType(inputType).equals(getType(mapping.getKey())))
+            {
+                return StringUtils.defaultIfBlank(mapping.getValue(), EMPTY_MIME_TYPE);
+            }
+        }
+        return DEFAULT_MIME_TYPES.entrySet().stream()
+                .filter(mapping -> mapping.getKey().equals("*"))
+                .findFirst()
+                .map(Map.Entry::getValue)
+                .orElse(EMPTY_MIME_TYPE);
     }
 }

--- a/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/mapper/MimeTypeMapperTest.java
+++ b/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/repository/mapper/MimeTypeMapperTest.java
@@ -1,0 +1,151 @@
+/*-
+ * #%L
+ * Alfresco HX Insight Connector
+ * %%
+ * Copyright (C) 2023 - 2024 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.mapper;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+
+import static org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.mapper.MimeTypeMapper.DEFAULT_MIME_TYPE;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.alfresco.hxi_connector.live_ingester.adapters.config.IntegrationProperties;
+import org.alfresco.hxi_connector.live_ingester.adapters.config.properties.Transform;
+
+@ExtendWith(MockitoExtension.class)
+class MimeTypeMapperTest
+{
+
+    @Mock
+    private IntegrationProperties mockIntegrationProperties;
+    @Mock
+    private IntegrationProperties.Alfresco mockAlfrescoProperties;
+    @Mock
+    private Transform mockTransformProperties;
+    @Mock
+    private Transform.MimeType mockMimeTypeProperties;
+
+    @InjectMocks
+    private MimeTypeMapper objectUnderTest;
+
+    @BeforeEach
+    void mockProperties()
+    {
+        given(mockIntegrationProperties.alfresco()).willReturn(mockAlfrescoProperties);
+        given(mockAlfrescoProperties.transform()).willReturn(mockTransformProperties);
+        given(mockTransformProperties.mimeType()).willReturn(mockMimeTypeProperties);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"text/plain", "application/pdf", "text/html", "image/png", "image/jpg", "image/gif", "application/msword"})
+    void givenNoMappingsConfigured_whenAnySourceMimeTypeAsInput_thenAlwaysReturnDefaultMimeType(String sourceMimeType)
+    {
+        given(mockMimeTypeProperties.mapping()).willReturn(null);
+        // when
+        String resultMimeType = objectUnderTest.mapMimeType(sourceMimeType);
+        // then
+        assertEquals(DEFAULT_MIME_TYPE, resultMimeType);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"text/html,application/pdf", "text/plain,application/pdf", "application/msword,application/pdf", "application/pdf,application/pdf"})
+    void givenExactMappingsConfigured_whenSourceMimeTypeMatchesTarget_thenReturnMatchingTargetMimeType(String sourceMimeType, String targetMimeType)
+    {
+        given(mockMimeTypeProperties.mapping()).willReturn(Map.of(sourceMimeType, targetMimeType));
+        // when
+        String resultMimeType = objectUnderTest.mapMimeType(sourceMimeType);
+        // then
+        assertEquals(targetMimeType, resultMimeType);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"image/png", "image/jpg", "image/gif", "text/richtext", "image/bmp"})
+    void givenExactMappingsConfigured_whenSourceMimeTypeMatchesNone_thenReturnEmptyMimeType(String sourceMimeType)
+    {
+        given(mockMimeTypeProperties.mapping()).willReturn(Map.of("text/html", "application/pdf",
+                "text/plain", "application/pdf",
+                "application/msword", "application/pdf",
+                "application/pdf", "application/pdf"));
+        // when
+        String resultMimeType = objectUnderTest.mapMimeType(sourceMimeType);
+        // then
+        assertEquals(MimeTypeMapper.EMPTY_MIME_TYPE, resultMimeType);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"image/png", "image/gif", "image/bmp"})
+    void givenExactAndSubtypeWildcardMappingsConfigured_whenSourceMimeTypeMatchesExactAndWildcard_thenReturnExactMimeType(String sourceMimeType)
+    {
+        String mimeTypePng = "image/png";
+        given(mockMimeTypeProperties.mapping()).willReturn(Map.of(mimeTypePng, mimeTypePng,
+                "image/bmp", mimeTypePng,
+                "image/gif", mimeTypePng,
+                "image/*", "image/jpg",
+                "*", "application/pdf"));
+        // when
+        String resultMimeType = objectUnderTest.mapMimeType(sourceMimeType);
+        // then
+        assertEquals(mimeTypePng, resultMimeType);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"image/png", "image/gif", "image/bmp"})
+    void givenOnlyExactAndSubtypeWildcardMappingsConfigured_whenSourceMimeTypeMatchesSubtypeWildcard_thenReturnSubtypeWildcardMimeType(String sourceMimeType)
+    {
+        String mimeTypeJpg = "image/jpg";
+        given(mockMimeTypeProperties.mapping()).willReturn(Map.of("image/*", mimeTypeJpg,
+                "*", "application/pdf"));
+        // when
+        String resultMimeType = objectUnderTest.mapMimeType(sourceMimeType);
+        // then
+        assertEquals(mimeTypeJpg, resultMimeType);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"text/html,application/pdf", "text/plain,application/pdf", "application/msword,application/pdf", "application/pdf,application/pdf",
+            "image/png,image/png", "image/gif,image/png", "image/bmp,image/png", "image/jpg,image/jpg", "image/tif,image/jpg", "text/richtext,application/pdf"})
+    void givenExactAndSubtypeWildcardMappingsConfigured_whenSourceMimeMapped_thenReturnTargetMimeTypeAsProvidedInParams(String sourceMimeType, String targetMimeType)
+    {
+        given(mockMimeTypeProperties.mapping()).willReturn(Map.of("image/png", "image/png",
+                "image/bmp", "image/png",
+                "image/gif", "image/png",
+                "image/*", "image/jpg",
+                "*", "application/pdf"));
+        // when
+        String resultMimeType = objectUnderTest.mapMimeType(sourceMimeType);
+        // when
+        assertEquals(targetMimeType, resultMimeType);
+    }
+}

--- a/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/content/IngestContentCommandHandlerTest.java
+++ b/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/content/IngestContentCommandHandlerTest.java
@@ -77,7 +77,7 @@ class IngestContentCommandHandlerTest
     void shouldRequestNodeContentTransformation()
     {
         // given
-        TriggerContentIngestionCommand command = new TriggerContentIngestionCommand(NODE_ID);
+        TriggerContentIngestionCommand command = new TriggerContentIngestionCommand(NODE_ID, PDF_MIMETYPE);
 
         // when
         ingestContentCommandHandler.handle(command);
@@ -92,7 +92,7 @@ class IngestContentCommandHandlerTest
     void shouldSendTransformedContentToIngestionEngine()
     {
         // given
-        IngestContentCommand command = new IngestContentCommand(FILE_ID, NODE_ID);
+        IngestContentCommand command = new IngestContentCommand(FILE_ID, NODE_ID, PDF_MIMETYPE);
 
         File fileToUpload = mock();
         given(transformEngineFileStorageMock.downloadFile(FILE_ID)).willReturn(fileToUpload);


### PR DESCRIPTION
A follow up to https://github.com/Alfresco/hxinsight-connector/pull/277
If no mime-type mapping is configured, then every content will be mapped to `application/pdf`.
If configured, mapping is done basing on following steps:
- look up exact mime-type mapping in configuration
- if above not found - look up wildcard subtype (`type/*`, e.g., `image/*`, `application/*` etc.) mapping in configuration
- if above not found - look up full wildcard mapping in configuration (`*`)

For instance, given following mapping configuration:
``` yml
    mime-type:
      mapping:
        '[image/png]': "image/png"
        '[image/bmp]': "image/png"
        '[image/gif]': "image/png"
        '[image/raw]': "image/png"
        '[image/*]': "image/jpeg"
        '[*]': "application/pdf"
```
` image/png`, `image/bmp`, `image/gif`, `image/raw` content type will request transforms to `image/png` content type.
All other `image` content types will be transformed to `image/jpeg` content type.
All other content types will be transformed to `application/pdf` content type.