### PR TITLE
ACS-6826 add method to pull enterprise repository image

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -138,7 +138,7 @@
         "filename": "common-test/src/main/java/org/alfresco/hxi_connector/common/test/docker/util/DockerContainers.java",
         "hashed_secret": "a4a747bd4ba5e3a5049cad116881867c71fb625b",
         "is_verified": false,
-        "line_number": 66,
+        "line_number": 68,
         "is_secret": false
       }
     ],
@@ -209,5 +209,5 @@
       }
     ]
   },
-  "generated_at": "2024-04-03T15:22:01Z"
+  "generated_at": "2024-04-22T08:50:27Z"
 }

--- a/common-test/src/main/java/org/alfresco/hxi_connector/common/test/docker/repository/AlfrescoRepositoryContainer.java
+++ b/common-test/src/main/java/org/alfresco/hxi_connector/common/test/docker/repository/AlfrescoRepositoryContainer.java
@@ -25,7 +25,11 @@
  */
 package org.alfresco.hxi_connector.common.test.docker.repository;
 
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.PullImageResultCallback;
+import com.github.dockerjava.api.model.PullResponseItem;
 import lombok.NonNull;
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -43,6 +47,20 @@ public class AlfrescoRepositoryContainer extends GenericContainer<AlfrescoReposi
     public AlfrescoRepositoryContainer()
     {
         this(false);
+    }
+
+    public static void pullRepositoryImage(boolean enterprise)
+    {
+        DockerClient dockerClient = DockerClientFactory.instance().client();
+        PullImageResultCallback callback = new PullImageResultCallback() {
+            @Override
+            public void onNext(PullResponseItem item)
+            {
+                super.onNext(item);
+            }
+        };
+        dockerClient.pullImageCmd(String.valueOf(DockerImageName.parse(!enterprise ? REPOSITORY_IMAGE_DEFAULT : REPOSITORY_ENTERPRISE_IMAGE_DEFAULT).withTag(REPOSITORY_TAG)))
+                .exec(callback);
     }
 
     public AlfrescoRepositoryContainer(boolean enterprise)

--- a/common-test/src/main/java/org/alfresco/hxi_connector/common/test/docker/util/DockerContainers.java
+++ b/common-test/src/main/java/org/alfresco/hxi_connector/common/test/docker/util/DockerContainers.java
@@ -25,6 +25,8 @@
  */
 package org.alfresco.hxi_connector.common.test.docker.util;
 
+import static org.alfresco.hxi_connector.common.test.docker.repository.AlfrescoRepositoryContainer.pullRepositoryImage;
+
 import java.time.Duration;
 import java.util.Optional;
 
@@ -82,6 +84,7 @@ public class DockerContainers
 
     public static AlfrescoRepositoryContainer createExtendedRepositoryContainerWithin(Network network, boolean enterprise)
     {
+        pullRepositoryImage(enterprise);
         AlfrescoRepositoryContainer repository = new AlfrescoRepositoryContainer(
                 new AlfrescoRepositoryExtension(
                         "alfresco-hxinsight-connector-prediction-applier-extension",

--- a/common-test/src/main/java/org/alfresco/hxi_connector/common/test/docker/util/DockerTags.java
+++ b/common-test/src/main/java/org/alfresco/hxi_connector/common/test/docker/util/DockerTags.java
@@ -42,7 +42,7 @@ import lombok.SneakyThrows;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class DockerTags
 {
-    private static final String REPOSITORY_TAG_DEFAULT = "23.1.0";
+    private static final String REPOSITORY_TAG_DEFAULT = "23.2.1";
     private static final String POSTGRES_TAG_DEFAULT = "14.4";
     private static final String ACTIVEMQ_TAG_DEFAULT = "5.18.3-jre17-rockylinux8";
     private static final String WIREMOCK_TAG_DEFAULT = "3.4.2";


### PR DESCRIPTION
[ACS-6826](https://hyland.atlassian.net/browse/ACS-6826)
This method is added so enterprise repository image would be downloaded when local run for test, which requires it, is performed.

[ACS-6826]: https://hyland.atlassian.net/browse/ACS-6826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ