### PR TITLE
[ACS-7949] Add new endpoint to confirm/reject predictions for node properties

### DIFF
--- a/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/PredictionChildrenRelation.java
+++ b/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/PredictionChildrenRelation.java
@@ -32,22 +32,16 @@ import java.util.List;
 import lombok.Setter;
 
 import org.alfresco.hxi_connector.prediction_applier.rest.api.model.PredictionModel;
-import org.alfresco.hxi_connector.prediction_applier.rest.api.model.ReviewStatus;
 import org.alfresco.hxi_connector.prediction_applier.service.PredictionService;
 import org.alfresco.hxi_connector.prediction_applier.service.model.Prediction;
 import org.alfresco.repo.transaction.RetryingTransactionHelper.RetryingTransactionCallback;
 import org.alfresco.rest.api.impl.NodesImpl;
-import org.alfresco.rest.framework.Operation;
-import org.alfresco.rest.framework.WebApiDescription;
-import org.alfresco.rest.framework.WebApiParam;
-import org.alfresco.rest.framework.core.ResourceParameter;
 import org.alfresco.rest.framework.resource.RelationshipResource;
 import org.alfresco.rest.framework.resource.actions.interfaces.RelationshipResourceAction;
 import org.alfresco.rest.framework.resource.parameters.CollectionWithPagingInfo;
 import org.alfresco.rest.framework.resource.parameters.ListPage;
 import org.alfresco.rest.framework.resource.parameters.Paging;
 import org.alfresco.rest.framework.resource.parameters.Parameters;
-import org.alfresco.rest.framework.webscripts.WithResponse;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.transaction.TransactionService;
 
@@ -56,7 +50,6 @@ import org.alfresco.service.transaction.TransactionService;
 public class PredictionChildrenRelation implements RelationshipResourceAction.Read<PredictionModel>,
         RelationshipResourceAction.Create<PredictionModel>
 {
-    private final String PARAM_REVIEW_STATUS = "reviewStatus";
     private NodesImpl nodes;
     private TransactionService transactionService;
     private PredictionService predictionService;
@@ -83,16 +76,5 @@ public class PredictionChildrenRelation implements RelationshipResourceAction.Re
         List<Prediction> outputPredictions = transactionService.getRetryingTransactionHelper().doInTransaction(callback, false, true);
 
         return outputPredictions.stream().map(PredictionModel::fromServiceModel).collect(toList());
-    }
-
-    @Operation("prediction-review")
-    @WebApiDescription(title = "Confirm or reject predictions on the node properties")
-    @WebApiParam(name = "predictions", title="predictions", description = "List of predictions to confirm/reject", kind= ResourceParameter.KIND.HTTP_BODY_OBJECT)
-    public void handlePredictions(String nodeId, List<Prediction> predictions, Parameters parameters, WithResponse withResponse)
-    {
-        NodeRef nodeRef = nodes.validateOrLookupNode(nodeId);
-        //TODO add IllegalArgumentException handling
-        ReviewStatus reviewStatus = ReviewStatus.valueOf(parameters.getParameter(PARAM_REVIEW_STATUS));
-        predictionService.handlePredictions(nodeRef, predictions, reviewStatus);
     }
 }

--- a/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/PredictionChildrenRelation.java
+++ b/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/PredictionChildrenRelation.java
@@ -32,16 +32,22 @@ import java.util.List;
 import lombok.Setter;
 
 import org.alfresco.hxi_connector.prediction_applier.rest.api.model.PredictionModel;
+import org.alfresco.hxi_connector.prediction_applier.rest.api.model.ReviewStatus;
 import org.alfresco.hxi_connector.prediction_applier.service.PredictionService;
 import org.alfresco.hxi_connector.prediction_applier.service.model.Prediction;
 import org.alfresco.repo.transaction.RetryingTransactionHelper.RetryingTransactionCallback;
 import org.alfresco.rest.api.impl.NodesImpl;
+import org.alfresco.rest.framework.Operation;
+import org.alfresco.rest.framework.WebApiDescription;
+import org.alfresco.rest.framework.WebApiParam;
+import org.alfresco.rest.framework.core.ResourceParameter;
 import org.alfresco.rest.framework.resource.RelationshipResource;
 import org.alfresco.rest.framework.resource.actions.interfaces.RelationshipResourceAction;
 import org.alfresco.rest.framework.resource.parameters.CollectionWithPagingInfo;
 import org.alfresco.rest.framework.resource.parameters.ListPage;
 import org.alfresco.rest.framework.resource.parameters.Paging;
 import org.alfresco.rest.framework.resource.parameters.Parameters;
+import org.alfresco.rest.framework.webscripts.WithResponse;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.transaction.TransactionService;
 
@@ -50,6 +56,7 @@ import org.alfresco.service.transaction.TransactionService;
 public class PredictionChildrenRelation implements RelationshipResourceAction.Read<PredictionModel>,
         RelationshipResourceAction.Create<PredictionModel>
 {
+    private final String PARAM_REVIEW_STATUS = "reviewStatus";
     private NodesImpl nodes;
     private TransactionService transactionService;
     private PredictionService predictionService;
@@ -76,5 +83,16 @@ public class PredictionChildrenRelation implements RelationshipResourceAction.Re
         List<Prediction> outputPredictions = transactionService.getRetryingTransactionHelper().doInTransaction(callback, false, true);
 
         return outputPredictions.stream().map(PredictionModel::fromServiceModel).collect(toList());
+    }
+
+    @Operation("prediction-review")
+    @WebApiDescription(title = "Confirm or reject predictions on the node properties")
+    @WebApiParam(name = "predictions", title="predictions", description = "List of predictions to confirm/reject", kind= ResourceParameter.KIND.HTTP_BODY_OBJECT)
+    public void handlePredictions(String nodeId, List<Prediction> predictions, Parameters parameters, WithResponse withResponse)
+    {
+        NodeRef nodeRef = nodes.validateOrLookupNode(nodeId);
+        //TODO add IllegalArgumentException handling
+        ReviewStatus reviewStatus = ReviewStatus.valueOf(parameters.getParameter(PARAM_REVIEW_STATUS));
+        predictionService.handlePredictions(nodeRef, predictions, reviewStatus);
     }
 }

--- a/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/PredictionsEntityResource.java
+++ b/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/PredictionsEntityResource.java
@@ -47,9 +47,9 @@ public class PredictionsEntityResource
 
     @Operation("review")
     @WebApiDescription(title = "Review prediction")
-    public void reviewPrediction(String predictionId, Void body, Parameters parameters, WithResponse withResponse)
+    public void reviewPrediction(String predictionNodeId, Void body, Parameters parameters, WithResponse withResponse)
     {
-        NodeRef predictionNodeRef = nodes.validateOrLookupNode(predictionId);
+        NodeRef predictionNodeRef = nodes.validateOrLookupNode(predictionNodeId);
         ReviewStatus reviewStatus = ReviewStatus.valueOf(parameters.getParameter(PARAM_REVIEW_STATUS));
         predictionService.reviewPrediction(predictionNodeRef, reviewStatus);
     }

--- a/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/PredictionsEntityResource.java
+++ b/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/PredictionsEntityResource.java
@@ -41,7 +41,7 @@ import org.alfresco.service.cmr.repository.NodeRef;
 @EntityResource(name = "predictions", title = "Predictions")
 public class PredictionsEntityResource
 {
-    private final String PARAM_REVIEW_STATUS = "reviewStatus";
+    private static final String PARAM_REVIEW_STATUS = "reviewStatus";
     private NodesImpl nodes;
     private PredictionService predictionService;
 

--- a/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/PredictionsEntityResource.java
+++ b/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/PredictionsEntityResource.java
@@ -50,7 +50,7 @@ public class PredictionsEntityResource
     public void reviewPrediction(String predictionNodeId, Void body, Parameters parameters, WithResponse withResponse)
     {
         NodeRef predictionNodeRef = nodes.validateOrLookupNode(predictionNodeId);
-        ReviewStatus reviewStatus = ReviewStatus.valueOf(parameters.getParameter(PARAM_REVIEW_STATUS));
+        ReviewStatus reviewStatus = ReviewStatus.fromString(parameters.getParameter(PARAM_REVIEW_STATUS));
         predictionService.reviewPrediction(predictionNodeRef, reviewStatus);
     }
 }

--- a/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/PredictionsEntityResource.java
+++ b/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/PredictionsEntityResource.java
@@ -1,0 +1,31 @@
+package org.alfresco.hxi_connector.prediction_applier.rest.api;
+
+import lombok.Setter;
+import org.alfresco.hxi_connector.prediction_applier.rest.api.model.ReviewStatus;
+import org.alfresco.hxi_connector.prediction_applier.service.PredictionService;
+import org.alfresco.rest.api.impl.NodesImpl;
+import org.alfresco.rest.framework.Operation;
+import org.alfresco.rest.framework.WebApiDescription;
+import org.alfresco.rest.framework.resource.EntityResource;
+import org.alfresco.rest.framework.resource.parameters.Parameters;
+import org.alfresco.rest.framework.webscripts.WithResponse;
+import org.alfresco.service.cmr.repository.NodeRef;
+
+@Setter
+@EntityResource(name="predictions", title = "Predictions")
+public class PredictionsEntityResource
+{
+    private final String PARAM_REVIEW_STATUS = "reviewStatus";
+    private NodesImpl nodes;
+    private PredictionService predictionService;
+
+    @Operation("review")
+    @WebApiDescription(title = "Review prediction")
+    public void reviewPrediction(String predictionId, Void body, Parameters parameters, WithResponse withResponse)
+    {
+        NodeRef predictionNodeRef = nodes.validateOrLookupNode(predictionId);
+        //TODO add IllegalArgumentException handling
+        ReviewStatus reviewStatus = ReviewStatus.valueOf(parameters.getParameter(PARAM_REVIEW_STATUS));
+        predictionService.reviewPrediction(predictionNodeRef, reviewStatus);
+    }
+}

--- a/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/PredictionsEntityResource.java
+++ b/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/PredictionsEntityResource.java
@@ -1,6 +1,32 @@
+/*-
+ * #%L
+ * Alfresco HX Insight Connector
+ * %%
+ * Copyright (C) 2023 - 2024 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
 package org.alfresco.hxi_connector.prediction_applier.rest.api;
 
 import lombok.Setter;
+
 import org.alfresco.hxi_connector.prediction_applier.rest.api.model.ReviewStatus;
 import org.alfresco.hxi_connector.prediction_applier.service.PredictionService;
 import org.alfresco.rest.api.impl.NodesImpl;
@@ -12,7 +38,7 @@ import org.alfresco.rest.framework.webscripts.WithResponse;
 import org.alfresco.service.cmr.repository.NodeRef;
 
 @Setter
-@EntityResource(name="predictions", title = "Predictions")
+@EntityResource(name = "predictions", title = "Predictions")
 public class PredictionsEntityResource
 {
     private final String PARAM_REVIEW_STATUS = "reviewStatus";
@@ -24,7 +50,6 @@ public class PredictionsEntityResource
     public void reviewPrediction(String predictionId, Void body, Parameters parameters, WithResponse withResponse)
     {
         NodeRef predictionNodeRef = nodes.validateOrLookupNode(predictionId);
-        //TODO add IllegalArgumentException handling
         ReviewStatus reviewStatus = ReviewStatus.valueOf(parameters.getParameter(PARAM_REVIEW_STATUS));
         predictionService.reviewPrediction(predictionNodeRef, reviewStatus);
     }

--- a/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/data_model/PredictionDataModel.java
+++ b/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/data_model/PredictionDataModel.java
@@ -46,6 +46,7 @@ public final class PredictionDataModel
     public static final QName PROP_PREDICTION_VALUE = QName.createQName(HXI_URI, "predictionValue");
     public static final QName PROP_PREVIOUS_VALUE = QName.createQName(HXI_URI, "previousValue");
     public static final QName PROP_UPDATE_TYPE = QName.createQName(HXI_URI, "updateType");
+    public static final QName PROP_REVIEW_STATUS = QName.createQName(HXI_URI, "reviewStatus");
 
     public static final QName PROP_LATEST_PREDICTION_DATE_TIME = QName.createQName(HXI_URI, "latestPredictionDateTime");
     public static final QName ASSOC_PREDICTED_BY = QName.createQName(HXI_URI, "predictedBy");

--- a/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/exception/PredictionStateChangedException.java
+++ b/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/exception/PredictionStateChangedException.java
@@ -25,7 +25,9 @@
  */
 package org.alfresco.hxi_connector.prediction_applier.rest.api.exception;
 
-public class PredictionStateChangedException extends RuntimeException
+import org.alfresco.error.AlfrescoRuntimeException;
+
+public class PredictionStateChangedException extends AlfrescoRuntimeException
 {
     public PredictionStateChangedException(String message)
     {

--- a/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/exception/PredictionStateChangedException.java
+++ b/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/exception/PredictionStateChangedException.java
@@ -1,0 +1,34 @@
+/*-
+ * #%L
+ * Alfresco HX Insight Connector
+ * %%
+ * Copyright (C) 2023 - 2024 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.hxi_connector.prediction_applier.rest.api.exception;
+
+public class PredictionStateChangedException extends RuntimeException
+{
+    public PredictionStateChangedException(String message)
+    {
+        super(message);
+    }
+}

--- a/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/model/PredictionModel.java
+++ b/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/model/PredictionModel.java
@@ -50,10 +50,11 @@ public class PredictionModel
     private Serializable predictionValue;
     private Serializable _previousValue;
     private UpdateType updateType;
+    private ReviewStatus reviewStatus;
 
     public Prediction toServiceModel()
     {
-        return new Prediction(_id, property, predictionDateTime, confidenceLevel, modelId, predictionValue, _previousValue, updateType);
+        return new Prediction(_id, property, predictionDateTime, confidenceLevel, modelId, predictionValue, _previousValue, updateType, reviewStatus);
     }
 
     public static PredictionModel fromServiceModel(Prediction prediction)
@@ -66,6 +67,7 @@ public class PredictionModel
                 prediction.getModelId(),
                 prediction.getPredictionValue(),
                 prediction.getPreviousValue(),
-                prediction.getUpdateType());
+                prediction.getUpdateType(),
+                prediction.getReviewStatus());
     }
 }

--- a/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/model/ReviewStatus.java
+++ b/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/model/ReviewStatus.java
@@ -1,0 +1,5 @@
+package org.alfresco.hxi_connector.prediction_applier.rest.api.model;
+
+public enum ReviewStatus {
+    UNREVIEWED, CONFIRMED, REJECTED
+}

--- a/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/model/ReviewStatus.java
+++ b/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/model/ReviewStatus.java
@@ -27,5 +27,24 @@ package org.alfresco.hxi_connector.prediction_applier.rest.api.model;
 
 public enum ReviewStatus
 {
-    UNREVIEWED, CONFIRMED, REJECTED
+    UNREVIEWED("unreviewed"), CONFIRMED("confirmed"), REJECTED("rejected");
+
+    private final String value;
+
+    ReviewStatus(String status)
+    {
+        value = status;
+    }
+
+    public static ReviewStatus fromString(String status)
+    {
+        for (ReviewStatus reviewStatus : ReviewStatus.values())
+        {
+            if (reviewStatus.value.equalsIgnoreCase(status))
+            {
+                return reviewStatus;
+            }
+        }
+        return null;
+    }
 }

--- a/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/model/ReviewStatus.java
+++ b/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/model/ReviewStatus.java
@@ -38,7 +38,7 @@ public enum ReviewStatus
 
     public static ReviewStatus fromString(String status)
     {
-        for (ReviewStatus reviewStatus : ReviewStatus.values())
+        for (ReviewStatus reviewStatus : values())
         {
             if (reviewStatus.value.equalsIgnoreCase(status))
             {

--- a/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/model/ReviewStatus.java
+++ b/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/model/ReviewStatus.java
@@ -1,5 +1,31 @@
+/*-
+ * #%L
+ * Alfresco HX Insight Connector
+ * %%
+ * Copyright (C) 2023 - 2024 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
 package org.alfresco.hxi_connector.prediction_applier.rest.api.model;
 
-public enum ReviewStatus {
+public enum ReviewStatus
+{
     UNREVIEWED, CONFIRMED, REJECTED
 }

--- a/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/service/PredictionService.java
+++ b/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/service/PredictionService.java
@@ -39,5 +39,5 @@ public interface PredictionService
 
     List<String> getPredictedProperties(NodeRef nodeRef);
 
-    void handlePredictions(NodeRef nodeRef, List<Prediction> predictions, ReviewStatus reviewStatus);
+    void reviewPrediction(NodeRef predictionNodeRef, ReviewStatus reviewStatus);
 }

--- a/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/service/PredictionService.java
+++ b/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/service/PredictionService.java
@@ -27,6 +27,7 @@ package org.alfresco.hxi_connector.prediction_applier.service;
 
 import java.util.List;
 
+import org.alfresco.hxi_connector.prediction_applier.rest.api.model.ReviewStatus;
 import org.alfresco.hxi_connector.prediction_applier.service.model.Prediction;
 import org.alfresco.service.cmr.repository.NodeRef;
 
@@ -37,4 +38,6 @@ public interface PredictionService
     List<Prediction> getPredictions(NodeRef nodeRef);
 
     List<String> getPredictedProperties(NodeRef nodeRef);
+
+    void handlePredictions(NodeRef nodeRef, List<Prediction> predictions, ReviewStatus reviewStatus);
 }

--- a/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/service/PredictionServiceImpl.java
+++ b/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/service/PredictionServiceImpl.java
@@ -172,36 +172,41 @@ public class PredictionServiceImpl implements PredictionService
         ChildAssociationRef parentAssocRef = nodeService.getPrimaryParent(predictionNodeRef);
         NodeRef parentNode = parentAssocRef.getParentRef();
         Map<QName, Serializable> existingProperties = new HashMap<>(nodeService.getProperties(parentNode));
-        Map<QName, Serializable> predictionNodeProperties = new HashMap<>(nodeService.getProperties(predictionNodeRef));
         Prediction prediction = childAssocToPrediction(parentAssocRef);
         QName propertyQName = QName.createQName(prediction.getProperty(), namespaceService);
         if (existingProperties.get(propertyQName).equals(prediction.getPredictionValue()))
         {
-            if (predictionNodeProperties.get(PROP_REVIEW_STATUS).equals(ReviewStatus.UNREVIEWED))
-            {
-                if (reviewStatus.equals(ReviewStatus.CONFIRMED))
-                {
-                    predictionNodeProperties.put(PROP_REVIEW_STATUS, ReviewStatus.CONFIRMED);
-                }
-                else if (reviewStatus.equals(ReviewStatus.REJECTED))
-                {
-                    existingProperties.put(propertyQName, prediction.getPreviousValue());
-                    nodeService.setProperties(parentNode, existingProperties);
-                    predictionNodeProperties.put(PROP_REVIEW_STATUS, ReviewStatus.REJECTED);
-                }
-                nodeService.setProperties(predictionNodeRef, predictionNodeProperties);
-            }
-            else
-            {
-                if (!reviewStatus.equals(prediction.getReviewStatus()))
-                {
-                    throw new PredictionStateChangedException("Prediction for " + prediction.getProperty() + " property has already been reviewed.");
-                }
-            }
+            updatePredictionState(predictionNodeRef, parentNode, existingProperties, prediction, propertyQName, reviewStatus);
         }
         else
         {
             throw new PredictionStateChangedException(prediction.getProperty() + " property value has changed, prediction is no longer valid!");
+        }
+    }
+
+    private void updatePredictionState(NodeRef predictionNodeRef, NodeRef parentNode, Map<QName, Serializable> parentNodeProperties, Prediction prediction, QName propertyQName, ReviewStatus reviewStatus) throws PredictionStateChangedException
+    {
+        Map<QName, Serializable> predictionNodeProperties = new HashMap<>(nodeService.getProperties(predictionNodeRef));
+        if (predictionNodeProperties.get(PROP_REVIEW_STATUS).equals(ReviewStatus.UNREVIEWED))
+        {
+            if (reviewStatus.equals(ReviewStatus.CONFIRMED))
+            {
+                predictionNodeProperties.put(PROP_REVIEW_STATUS, ReviewStatus.CONFIRMED);
+            }
+            else if (reviewStatus.equals(ReviewStatus.REJECTED))
+            {
+                parentNodeProperties.put(propertyQName, prediction.getPreviousValue());
+                nodeService.setProperties(parentNode, parentNodeProperties);
+                predictionNodeProperties.put(PROP_REVIEW_STATUS, ReviewStatus.REJECTED);
+            }
+            nodeService.setProperties(predictionNodeRef, predictionNodeProperties);
+        }
+        else
+        {
+            if (!reviewStatus.equals(prediction.getReviewStatus()))
+            {
+                throw new PredictionStateChangedException("Prediction for " + prediction.getProperty() + " property has already been reviewed.");
+            }
         }
     }
 }

--- a/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/service/PredictionServiceImpl.java
+++ b/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/service/PredictionServiceImpl.java
@@ -54,7 +54,6 @@ import org.alfresco.hxi_connector.prediction_applier.rest.api.exception.Predicti
 import org.alfresco.hxi_connector.prediction_applier.rest.api.model.ReviewStatus;
 import org.alfresco.hxi_connector.prediction_applier.rest.api.model.UpdateType;
 import org.alfresco.hxi_connector.prediction_applier.service.model.Prediction;
-import org.alfresco.rest.framework.core.exceptions.EntityNotFoundException;
 import org.alfresco.service.cmr.repository.ChildAssociationRef;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.cmr.repository.NodeService;
@@ -168,7 +167,7 @@ public class PredictionServiceImpl implements PredictionService
     }
 
     @Override
-    public void reviewPrediction(NodeRef predictionNodeRef, ReviewStatus reviewStatus) throws EntityNotFoundException, PredictionStateChangedException
+    public void reviewPrediction(NodeRef predictionNodeRef, ReviewStatus reviewStatus) throws PredictionStateChangedException
     {
         ChildAssociationRef parentAssocRef = nodeService.getPrimaryParent(predictionNodeRef);
         NodeRef parentNode = parentAssocRef.getParentRef();

--- a/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/service/model/Prediction.java
+++ b/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/service/model/Prediction.java
@@ -31,6 +31,7 @@ import java.util.Date;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+import org.alfresco.hxi_connector.prediction_applier.rest.api.model.ReviewStatus;
 import org.alfresco.hxi_connector.prediction_applier.rest.api.model.UpdateType;
 
 @Data
@@ -45,4 +46,5 @@ public class Prediction
     private Serializable predictionValue;
     private Serializable previousValue;
     private UpdateType updateType;
+    private ReviewStatus reviewStatus;
 }

--- a/prediction-applier-extension/src/main/resources/alfresco/module/alfresco-hxinsight-connector-prediction-applier-extension/context/service-context.xml
+++ b/prediction-applier-extension/src/main/resources/alfresco/module/alfresco-hxinsight-connector-prediction-applier-extension/context/service-context.xml
@@ -72,4 +72,16 @@
         <property name="nodes" ref="nodes"/>
         <property name="predictionService" ref="PredictionService"/>
     </bean>
+
+    <bean id="hxi.simpleMappingExceptionResolver" abstract="true" parent="simpleMappingExceptionResolverParent">
+        <property name="exceptionMappings">
+            <map merge="true">
+                <entry key="org.alfresco.hxi_connector.prediction_applier.rest.api.exception.PredictionStateChangedException" value="#{T(org.springframework.extensions.webscripts.Status).STATUS_CONFLICT}" />
+            </map>
+        </property>
+    </bean>
+    <bean class="org.alfresco.util.BeanExtender">
+        <property name="beanName" value="simpleMappingExceptionResolverParent"/>
+        <property name="extendingBeanName" value="hxi.simpleMappingExceptionResolver"/>
+    </bean>
 </beans>

--- a/prediction-applier-extension/src/main/resources/alfresco/module/alfresco-hxinsight-connector-prediction-applier-extension/context/service-context.xml
+++ b/prediction-applier-extension/src/main/resources/alfresco/module/alfresco-hxinsight-connector-prediction-applier-extension/context/service-context.xml
@@ -67,4 +67,9 @@
         <property name="transactionService" ref="TransactionService"/>
         <property name="predictionService" ref="PredictionService"/>
     </bean>
+
+    <bean class="org.alfresco.hxi_connector.prediction_applier.rest.api.PredictionsEntityResource">
+        <property name="nodes" ref="nodes"/>
+        <property name="predictionService" ref="PredictionService"/>
+    </bean>
 </beans>

--- a/prediction-applier-extension/src/test/java/org/alfresco/hxi_connector/prediction_applier/service/PredictionServiceImplTest.java
+++ b/prediction-applier-extension/src/test/java/org/alfresco/hxi_connector/prediction_applier/service/PredictionServiceImplTest.java
@@ -61,7 +61,6 @@ import org.alfresco.hxi_connector.common.exception.ValidationException;
 import org.alfresco.hxi_connector.prediction_applier.rest.api.exception.PredictionStateChangedException;
 import org.alfresco.hxi_connector.prediction_applier.rest.api.model.ReviewStatus;
 import org.alfresco.hxi_connector.prediction_applier.service.model.Prediction;
-import org.alfresco.rest.framework.core.exceptions.EntityNotFoundException;
 import org.alfresco.service.cmr.repository.ChildAssociationRef;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.cmr.repository.NodeService;
@@ -133,7 +132,8 @@ public class PredictionServiceImplTest
                 PROP_MODEL_ID, "hx-model-id",
                 PROP_PREDICTION_VALUE, "blue",
                 PROP_PREVIOUS_VALUE, "red",
-                PROP_UPDATE_TYPE, AUTOCORRECT.name());
+                PROP_UPDATE_TYPE, AUTOCORRECT.name(),
+                PROP_REVIEW_STATUS, ReviewStatus.UNREVIEWED);
         given(nodeService.getProperties(PREDICTION_NODE_REF)).willReturn(properties);
         given(nodeService.getChildAssocs(NODE_REF, Set.of(TYPE_PREDICTION))).willReturn(List.of(CHILD_ASSOC_REF));
         given(namespaceService.getPrefixes(NAMESPACE)).willReturn(Set.of(NAMESPACE_PREFIX));
@@ -160,7 +160,8 @@ public class PredictionServiceImplTest
                 PROP_MODEL_ID, "hx-model-id",
                 PROP_PREDICTION_VALUE, "blue",
                 PROP_PREVIOUS_VALUE, "red",
-                PROP_UPDATE_TYPE, AUTOCORRECT);
+                PROP_UPDATE_TYPE, AUTOCORRECT,
+                PROP_REVIEW_STATUS, ReviewStatus.UNREVIEWED);
         given(nodeService.createNode(NODE_REF, ASSOC_PREDICTED_BY, PROPERTY_QNAME, TYPE_PREDICTION, expectedProperties)).willReturn(CHILD_ASSOC_REF);
 
         // when
@@ -240,17 +241,6 @@ public class PredictionServiceImplTest
     }
 
     @Test
-    public void testReviewPrediction_missingPrediction()
-    {
-        // given
-        NodeRef mismatchedPredictionNodeRef = new NodeRef("node://test/");
-        given(nodeService.getParentAssocs(mismatchedPredictionNodeRef)).willReturn(List.of(CHILD_ASSOC_REF));
-
-        // when
-        assertThrows(EntityNotFoundException.class, () -> predictionService.reviewPrediction(mismatchedPredictionNodeRef, ReviewStatus.CONFIRMED));
-    }
-
-    @Test
     public void testReviewPrediction_propertyValueChangedBeforePredictionReview()
     {
         // given
@@ -316,7 +306,6 @@ public class PredictionServiceImplTest
         given(nodeService.getProperties(PREDICTION_NODE_REF)).willReturn(properties);
         given(namespaceService.getNamespaceURI(NAMESPACE_PREFIX)).willReturn(NAMESPACE);
         given(namespaceService.getPrefixes(NAMESPACE)).willReturn(Set.of(NAMESPACE_PREFIX));
-        given(nodeService.getChildAssocs(NODE_REF, Set.of(TYPE_PREDICTION))).willReturn(List.of(CHILD_ASSOC_REF));
-        given(nodeService.getParentAssocs(PREDICTION_NODE_REF)).willReturn(List.of(CHILD_ASSOC_REF));
+        given(nodeService.getPrimaryParent(PREDICTION_NODE_REF)).willReturn(CHILD_ASSOC_REF);
     }
 }


### PR DESCRIPTION
PR adding new endpoint to either confirm or reject prediction for node properties.