### PR TITLE
ACS-7605: Initial version of handling various authentication ACS methods 

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -220,12 +220,20 @@
       {
         "type": "Secret Keyword",
         "filename": "prediction-applier/src/main/resources/application.yml",
+        "hashed_secret": "40f81ac66c7cb246ded7b83e15ca0bf5d7f57eee",
+        "is_verified": false,
+        "line_number": 16,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "prediction-applier/src/main/resources/application.yml",
         "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
         "is_verified": false,
-        "line_number": 40,
+        "line_number": 47,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2024-05-14T15:01:02Z"
+  "generated_at": "2024-05-22T07:41:41Z"
 }

--- a/common-authentication/src/integration-test/java/org/alfresco/hxi_connector/common/adapters/auth/HxAuthenticationClientTest.java
+++ b/common-authentication/src/integration-test/java/org/alfresco/hxi_connector/common/adapters/auth/HxAuthenticationClientTest.java
@@ -142,7 +142,7 @@ public abstract class HxAuthenticationClientTest
     @DynamicPropertySource
     protected static void overrideProperties(DynamicPropertyRegistry registry)
     {
-        AuthUtils.overrideAuthProperties(registry, hxAuthMock.getBaseUrl());
+        AuthUtils.overrideAuthProperties(registry, hxAuthMock.getBaseUrl(), "hyland-experience-auth");
         registry.add("hyland-experience.authentication.retry.attempts", () -> RETRY_ATTEMPTS);
         registry.add("hyland-experience.authentication.retry.initialDelay", () -> RETRY_DELAY_MS);
     }

--- a/common-authentication/src/integration-test/java/org/alfresco/hxi_connector/common/adapters/auth/util/AuthUtils.java
+++ b/common-authentication/src/integration-test/java/org/alfresco/hxi_connector/common/adapters/auth/util/AuthUtils.java
@@ -97,13 +97,13 @@ public class AuthUtils
         return TOKEN_TYPE + " " + ACCESS_TOKEN;
     }
 
-    public static void overrideAuthProperties(DynamicPropertyRegistry registry, String mockServerBaseUrl)
+    public static void overrideAuthProperties(DynamicPropertyRegistry registry, String mockServerBaseUrl, String clientRegistrationId)
     {
-        registry.add("spring.security.oauth2.client.registration.hyland-experience-auth.client-id", () -> CLIENT_ID);
-        registry.add("spring.security.oauth2.client.registration.hyland-experience-auth.client-secret", () -> CLIENT_SECRET);
-        registry.add("spring.security.oauth2.client.registration.hyland-experience-auth.client-name", () -> CLIENT_NAME);
-        registry.add("spring.security.oauth2.client.registration.hyland-experience-auth.authorization-grant-type", () -> AUTH_GRAND_TYPE);
-        registry.add("spring.security.oauth2.client.registration.hyland-experience-auth.scope", () -> SCOPE);
-        registry.add("spring.security.oauth2.client.provider.hyland-experience-auth.token-uri", () -> mockServerBaseUrl + TOKEN_PATH);
+        registry.add("spring.security.oauth2.client.registration." + clientRegistrationId + ".client-id", () -> CLIENT_ID);
+        registry.add("spring.security.oauth2.client.registration." + clientRegistrationId + ".client-secret", () -> CLIENT_SECRET);
+        registry.add("spring.security.oauth2.client.registration." + clientRegistrationId + ".client-name", () -> CLIENT_NAME);
+        registry.add("spring.security.oauth2.client.registration." + clientRegistrationId + ".authorization-grant-type", () -> AUTH_GRAND_TYPE);
+        registry.add("spring.security.oauth2.client.registration." + clientRegistrationId + ".scope", () -> SCOPE);
+        registry.add("spring.security.oauth2.client.provider." + clientRegistrationId + ".token-uri", () -> mockServerBaseUrl + TOKEN_PATH);
     }
 }

--- a/common-authentication/src/main/java/org/alfresco/hxi_connector/common/adapters/auth/AccessTokenProvider.java
+++ b/common-authentication/src/main/java/org/alfresco/hxi_connector/common/adapters/auth/AccessTokenProvider.java
@@ -1,4 +1,4 @@
-/*
+/*-
  * #%L
  * Alfresco HX Insight Connector
  * %%
@@ -25,15 +25,7 @@
  */
 package org.alfresco.hxi_connector.common.adapters.auth;
 
-import org.springframework.security.oauth2.client.registration.ClientRegistration;
-
-public interface AuthenticationClient
+public interface AccessTokenProvider
 {
-
-    AuthenticationResult authenticate(String tokenUri, ClientRegistration clientRegistration);
-
-    default AuthenticationResult authenticate(String clientRegistrationId)
-    {
-        throw new UnsupportedOperationException("This method is not supported by this client");
-    }
+    String getAccessToken(String clientRegistrationId);
 }

--- a/common-authentication/src/main/java/org/alfresco/hxi_connector/common/adapters/auth/AuthenticationResult.java
+++ b/common-authentication/src/main/java/org/alfresco/hxi_connector/common/adapters/auth/AuthenticationResult.java
@@ -34,11 +34,13 @@ import java.time.temporal.TemporalUnit;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.springframework.validation.annotation.Validated;
 
 @Validated
 @SuppressWarnings("PMD.UnusedAssignment")
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record AuthenticationResult(
         @NotBlank @JsonProperty("access_token") String accessToken,
         @Positive @JsonProperty("expires_in") int expiresIn,

--- a/common-authentication/src/main/java/org/alfresco/hxi_connector/common/adapters/auth/DefaultAccessTokenProvider.java
+++ b/common-authentication/src/main/java/org/alfresco/hxi_connector/common/adapters/auth/DefaultAccessTokenProvider.java
@@ -1,0 +1,84 @@
+/*-
+ * #%L
+ * Alfresco HX Insight Connector
+ * %%
+ * Copyright (C) 2023 - 2024 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.hxi_connector.common.adapters.auth;
+
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.camel.CamelContext;
+
+import org.alfresco.hxi_connector.common.exception.HxInsightConnectorRuntimeException;
+
+@RequiredArgsConstructor
+public class DefaultAccessTokenProvider implements AccessTokenProvider
+{
+
+    private final CamelContext camelContext;
+    private final AuthenticationClient authenticationClient;
+
+    private Map<String, Map.Entry<AuthenticationResult, OffsetDateTime>> accessTokens = new HashMap<>();
+
+    public String getAccessToken(String clientRegistrationId)
+    {
+        waitFor(camelContext::isStarted);
+        Map.Entry<AuthenticationResult, OffsetDateTime> authenticationResultEntry = accessTokens.get(clientRegistrationId);
+        if (authenticationResultEntry == null || authenticationResultEntry.getValue().isBefore(OffsetDateTime.now()))
+        {
+            refreshAuthenticationResult(clientRegistrationId);
+            authenticationResultEntry = accessTokens.get(clientRegistrationId);
+        }
+        Objects.requireNonNull(authenticationResultEntry, "Authentication result is null");
+        AuthenticationResult authenticationResult = authenticationResultEntry.getKey();
+        return authenticationResult.accessToken();
+    }
+
+    private void refreshAuthenticationResult(String clientRegistrationId)
+    {
+        AuthenticationResult authenticationResult = authenticationClient.authenticate(clientRegistrationId);
+        accessTokens.put(clientRegistrationId, Map.entry(authenticationResult,
+                OffsetDateTime.now().plus(authenticationResult.expiresIn(), authenticationResult.temporalUnit())));
+    }
+
+    private static void waitFor(Supplier<Boolean> supplier)
+    {
+        while (!supplier.get())
+        {
+            try
+            {
+                TimeUnit.MILLISECONDS.sleep(100);
+            }
+            catch (InterruptedException e)
+            {
+                throw new HxInsightConnectorRuntimeException(e);
+            }
+        }
+    }
+}

--- a/common-authentication/src/main/java/org/alfresco/hxi_connector/common/adapters/auth/DefaultAccessTokenProvider.java
+++ b/common-authentication/src/main/java/org/alfresco/hxi_connector/common/adapters/auth/DefaultAccessTokenProvider.java
@@ -44,8 +44,9 @@ public class DefaultAccessTokenProvider implements AccessTokenProvider
     private final CamelContext camelContext;
     private final AuthenticationClient authenticationClient;
 
-    private Map<String, Map.Entry<AuthenticationResult, OffsetDateTime>> accessTokens = new HashMap<>();
+    private final Map<String, Map.Entry<AuthenticationResult, OffsetDateTime>> accessTokens = new HashMap<>();
 
+    @Override
     public String getAccessToken(String clientRegistrationId)
     {
         waitFor(camelContext::isStarted);

--- a/common-authentication/src/main/java/org/alfresco/hxi_connector/common/adapters/auth/TokenRequest.java
+++ b/common-authentication/src/main/java/org/alfresco/hxi_connector/common/adapters/auth/TokenRequest.java
@@ -49,8 +49,7 @@ public class TokenRequest
     public String getTokenRequestBody()
     {
         StringBuilder body = new StringBuilder();
-        body.append("grant_type=").append(encode(this.grantType, UTF_8));
-        body.append("&client_id=").append(encode(clientId, UTF_8));
+        body.append("grant_type=").append(encode(this.grantType, UTF_8)).append("&client_id=").append(encode(clientId, UTF_8));
         if (Strings.isNotBlank(this.clientSecret))
         {
             body.append("&client_secret=").append(encode(this.clientSecret, UTF_8));

--- a/common-authentication/src/main/java/org/alfresco/hxi_connector/common/adapters/auth/TokenRequest.java
+++ b/common-authentication/src/main/java/org/alfresco/hxi_connector/common/adapters/auth/TokenRequest.java
@@ -1,0 +1,144 @@
+/*-
+ * #%L
+ * Alfresco HX Insight Connector
+ * %%
+ * Copyright (C) 2023 - 2024 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.hxi_connector.common.adapters.auth;
+
+import static java.net.URLEncoder.encode;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.util.Set;
+
+import lombok.AllArgsConstructor;
+import lombok.ToString;
+import org.apache.logging.log4j.util.Strings;
+import org.springframework.util.CollectionUtils;
+
+@AllArgsConstructor
+@ToString
+public class TokenRequest
+{
+    private String grantType;
+    private String clientId;
+    private String clientSecret;
+    private Set<String> scope;
+    private String username;
+    private String password;
+
+    public String getTokenRequestBody()
+    {
+        StringBuilder body = new StringBuilder();
+        body.append("grant_type=").append(encode(this.grantType, UTF_8));
+        body.append("&client_id=").append(encode(clientId, UTF_8));
+        if (Strings.isNotBlank(this.clientSecret))
+        {
+            body.append("&client_secret=").append(encode(this.clientSecret, UTF_8));
+        }
+        if (!CollectionUtils.isEmpty(this.scope))
+        {
+            body.append("&scope=").append(encode(String.join(",", this.scope), UTF_8));
+        }
+        if (Strings.isNotBlank(this.username))
+        {
+            body.append("&username=").append(encode(this.username, UTF_8));
+        }
+        if (Strings.isNotBlank(this.password))
+        {
+            body.append("&password=").append(encode(this.password, UTF_8));
+        }
+
+        return body.toString();
+    }
+
+    public static TokenRequestBuilder builder()
+    {
+        return new TokenRequestBuilder();
+    }
+
+    public static class TokenRequestBuilder
+    {
+        private String grantType;
+        private String clientId;
+        private String clientSecret;
+        private Set<String> scope;
+        private String username;
+        private String password;
+
+        TokenRequestBuilder()
+        {}
+
+        public TokenRequestBuilder grantType(String grantType)
+        {
+            this.grantType = grantType;
+            return this;
+        }
+
+        public TokenRequestBuilder clientId(String clientId)
+        {
+            this.clientId = clientId;
+            return this;
+        }
+
+        public TokenRequestBuilder clientSecret(String clientSecret)
+        {
+            if (Strings.isNotBlank(clientSecret))
+            {
+                this.clientSecret = clientSecret;
+            }
+            return this;
+        }
+
+        public TokenRequestBuilder scope(Set<String> scope)
+        {
+            if (!CollectionUtils.isEmpty(scope))
+            {
+                this.scope = scope;
+            }
+            return this;
+        }
+
+        public TokenRequestBuilder username(String username)
+        {
+            if (Strings.isNotBlank(username))
+            {
+                this.username = username;
+            }
+            return this;
+        }
+
+        public TokenRequestBuilder password(String password)
+        {
+            if (Strings.isNotBlank(password))
+            {
+                this.password = password;
+            }
+            return this;
+        }
+
+        public TokenRequest build()
+        {
+            return new TokenRequest(this.grantType, this.clientId, this.clientSecret, this.scope, this.username, this.password);
+        }
+    }
+}

--- a/common-authentication/src/main/java/org/alfresco/hxi_connector/common/adapters/auth/TokenRequest.java
+++ b/common-authentication/src/main/java/org/alfresco/hxi_connector/common/adapters/auth/TokenRequest.java
@@ -31,12 +31,14 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import java.util.Set;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.ToString;
 import org.apache.logging.log4j.util.Strings;
 import org.springframework.util.CollectionUtils;
 
 @AllArgsConstructor
 @ToString
+@Builder
 public class TokenRequest
 {
     private String grantType;
@@ -48,7 +50,7 @@ public class TokenRequest
 
     public String getTokenRequestBody()
     {
-        StringBuilder body = new StringBuilder();
+        final StringBuilder body = new StringBuilder();
         body.append("grant_type=").append(encode(this.grantType, UTF_8)).append("&client_id=").append(encode(clientId, UTF_8));
         if (Strings.isNotBlank(this.clientSecret))
         {
@@ -68,76 +70,5 @@ public class TokenRequest
         }
 
         return body.toString();
-    }
-
-    public static TokenRequestBuilder builder()
-    {
-        return new TokenRequestBuilder();
-    }
-
-    public static class TokenRequestBuilder
-    {
-        private String grantType;
-        private String clientId;
-        private String clientSecret;
-        private Set<String> scope;
-        private String username;
-        private String password;
-
-        TokenRequestBuilder()
-        {}
-
-        public TokenRequestBuilder grantType(String grantType)
-        {
-            this.grantType = grantType;
-            return this;
-        }
-
-        public TokenRequestBuilder clientId(String clientId)
-        {
-            this.clientId = clientId;
-            return this;
-        }
-
-        public TokenRequestBuilder clientSecret(String clientSecret)
-        {
-            if (Strings.isNotBlank(clientSecret))
-            {
-                this.clientSecret = clientSecret;
-            }
-            return this;
-        }
-
-        public TokenRequestBuilder scope(Set<String> scope)
-        {
-            if (!CollectionUtils.isEmpty(scope))
-            {
-                this.scope = scope;
-            }
-            return this;
-        }
-
-        public TokenRequestBuilder username(String username)
-        {
-            if (Strings.isNotBlank(username))
-            {
-                this.username = username;
-            }
-            return this;
-        }
-
-        public TokenRequestBuilder password(String password)
-        {
-            if (Strings.isNotBlank(password))
-            {
-                this.password = password;
-            }
-            return this;
-        }
-
-        public TokenRequest build()
-        {
-            return new TokenRequest(this.grantType, this.clientId, this.clientSecret, this.scope, this.username, this.password);
-        }
     }
 }

--- a/common-authentication/src/test/java/org/alfresco/hxi_connector/common/adapters/auth/DefaultAccessTokenProviderTest.java
+++ b/common-authentication/src/test/java/org/alfresco/hxi_connector/common/adapters/auth/DefaultAccessTokenProviderTest.java
@@ -66,7 +66,7 @@ class DefaultAccessTokenProviderTest
     }
 
     @Test
-    void getAccessToken_whenTokenNotPresent_shouldRefreshToken()
+    void givenTokenNotPresent_whenGetAccessToken_thenRefreshToken()
     {
         AuthenticationResult mockResult = Mockito.mock(AuthenticationResult.class);
         given(mockResult.accessToken()).willReturn(TEST_TOKEN);
@@ -83,7 +83,7 @@ class DefaultAccessTokenProviderTest
     }
 
     @Test
-    void getAccessToken_whenTokenExpired_shouldRefreshToken()
+    void givenTokenExpired_whenGetAccessToken_thenRefreshToken()
     {
         AuthenticationResult mockResult = Mockito.mock(AuthenticationResult.class);
         given(mockResult.accessToken()).willReturn(TEST_TOKEN);
@@ -104,7 +104,7 @@ class DefaultAccessTokenProviderTest
     }
 
     @Test
-    void getAccessToken_whenTokenValid_shouldNotRefreshToken()
+    void givenTokenValid_whenGetAccessToken_thenReturnTokenWithoutRefresh()
     {
         AuthenticationResult mockResult = Mockito.mock(AuthenticationResult.class);
         given(mockResult.accessToken()).willReturn(TEST_TOKEN);
@@ -121,7 +121,7 @@ class DefaultAccessTokenProviderTest
     }
 
     @Test
-    void getAccessToken_whenAuthenticationError_shouldThrowException()
+    void givenAuthenticationError_whenGetAccessToken_thenThrowException()
     {
         given(mockAuthenticationClient.authenticate(CLIENT_REGISTRATION_ID)).willThrow(RuntimeException.class);
 

--- a/common-authentication/src/test/java/org/alfresco/hxi_connector/common/adapters/auth/DefaultAccessTokenProviderTest.java
+++ b/common-authentication/src/test/java/org/alfresco/hxi_connector/common/adapters/auth/DefaultAccessTokenProviderTest.java
@@ -1,0 +1,132 @@
+/*-
+ * #%L
+ * Alfresco HX Insight Connector
+ * %%
+ * Copyright (C) 2023 - 2024 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.hxi_connector.common.adapters.auth;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.camel.CamelContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultAccessTokenProviderTest
+{
+
+    private static final String CLIENT_REGISTRATION_ID = "testClient";
+    private static final String TEST_TOKEN = "testToken";
+    @Mock
+    private CamelContext mockCamelContext;
+    @Mock
+    private AuthenticationClient mockAuthenticationClient;
+
+    @InjectMocks
+    private DefaultAccessTokenProvider objectUnderTest;
+
+    @BeforeEach
+    void setUp()
+    {
+        given(mockCamelContext.isStarted()).willReturn(true);
+    }
+
+    @Test
+    void getAccessToken_whenTokenNotPresent_shouldRefreshToken()
+    {
+        AuthenticationResult mockResult = Mockito.mock(AuthenticationResult.class);
+        given(mockResult.accessToken()).willReturn(TEST_TOKEN);
+        given(mockResult.expiresIn()).willReturn(3600);
+        given(mockResult.temporalUnit()).willReturn(ChronoUnit.SECONDS);
+        given(mockAuthenticationClient.authenticate(CLIENT_REGISTRATION_ID)).willReturn(mockResult);
+
+        // when
+        String token = objectUnderTest.getAccessToken(CLIENT_REGISTRATION_ID);
+
+        then(mockAuthenticationClient).should().authenticate(CLIENT_REGISTRATION_ID);
+        then(mockAuthenticationClient).shouldHaveNoMoreInteractions();
+        assertEquals(TEST_TOKEN, token);
+    }
+
+    @Test
+    void getAccessToken_whenTokenExpired_shouldRefreshToken()
+    {
+        AuthenticationResult mockResult = Mockito.mock(AuthenticationResult.class);
+        given(mockResult.accessToken()).willReturn(TEST_TOKEN);
+        given(mockResult.expiresIn()).willReturn(3600);
+        given(mockResult.temporalUnit()).willReturn(ChronoUnit.SECONDS);
+        given(mockAuthenticationClient.authenticate(CLIENT_REGISTRATION_ID)).willReturn(mockResult);
+
+        Map<String, Map.Entry<AuthenticationResult, OffsetDateTime>> tokens = new HashMap<>();
+        tokens.put(CLIENT_REGISTRATION_ID, Map.entry(mockResult, OffsetDateTime.now().minusSeconds(1)));
+        ReflectionTestUtils.setField(objectUnderTest, "accessTokens", tokens);
+
+        // when
+        String token = objectUnderTest.getAccessToken(CLIENT_REGISTRATION_ID);
+
+        then(mockAuthenticationClient).should().authenticate(CLIENT_REGISTRATION_ID);
+        then(mockAuthenticationClient).shouldHaveNoMoreInteractions();
+        assertEquals(TEST_TOKEN, token);
+    }
+
+    @Test
+    void getAccessToken_whenTokenValid_shouldNotRefreshToken()
+    {
+        AuthenticationResult mockResult = Mockito.mock(AuthenticationResult.class);
+        given(mockResult.accessToken()).willReturn(TEST_TOKEN);
+
+        Map<String, Map.Entry<AuthenticationResult, OffsetDateTime>> tokens = new HashMap<>();
+        tokens.put(CLIENT_REGISTRATION_ID, Map.entry(mockResult, OffsetDateTime.now().plusSeconds(3600)));
+        ReflectionTestUtils.setField(objectUnderTest, "accessTokens", tokens);
+
+        // when
+        String token = objectUnderTest.getAccessToken(CLIENT_REGISTRATION_ID);
+
+        then(mockAuthenticationClient).shouldHaveNoInteractions();
+        assertEquals(TEST_TOKEN, token);
+    }
+
+    @Test
+    void getAccessToken_whenAuthenticationError_shouldThrowException()
+    {
+        given(mockAuthenticationClient.authenticate(CLIENT_REGISTRATION_ID)).willThrow(RuntimeException.class);
+
+        // then
+        assertThrows(RuntimeException.class, () -> objectUnderTest.getAccessToken(CLIENT_REGISTRATION_ID));
+    }
+
+}

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/util/E2ETestBase.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/util/E2ETestBase.java
@@ -102,7 +102,7 @@ public class E2ETestBase
     @DynamicPropertySource
     static void configureProperties(DynamicPropertyRegistry registry)
     {
-        AuthUtils.overrideAuthProperties(registry, hxAuthServer.getBaseUrl());
+        AuthUtils.overrideAuthProperties(registry, hxAuthServer.getBaseUrl(), "hyland-experience-auth");
 
         brokerUrl = "tcp://localhost:" + activemqBroker.getFirstMappedPort();
         registry.add("spring.activemq.broker-url", () -> brokerUrl);

--- a/prediction-applier/src/integration-test/java/org/alfresco/hxi_connector/prediction_applier/adapters/auth/PredictionApplierHxAuthClientIntegrationTest.java
+++ b/prediction-applier/src/integration-test/java/org/alfresco/hxi_connector/prediction_applier/adapters/auth/PredictionApplierHxAuthClientIntegrationTest.java
@@ -45,6 +45,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -56,8 +58,13 @@ import org.alfresco.hxi_connector.common.adapters.auth.AuthenticationResult;
 import org.alfresco.hxi_connector.common.adapters.auth.HxAuthenticationClientTest;
 import org.alfresco.hxi_connector.common.adapters.auth.util.AuthUtils;
 import org.alfresco.hxi_connector.common.test.docker.util.DockerContainers;
+import org.alfresco.hxi_connector.prediction_applier.auth.PredictionApplierHxAuthClient;
+import org.alfresco.hxi_connector.prediction_applier.config.HxInsightProperties;
+import org.alfresco.hxi_connector.prediction_applier.config.NodesApiProperties;
+import org.alfresco.hxi_connector.prediction_applier.config.SecurityConfig;
 
-@SpringBootTest(properties = "logging.level.org.alfresco=DEBUG")
+@SpringBootTest(properties = "logging.level.org.alfresco=DEBUG",
+        classes = {HxInsightProperties.class, SecurityConfig.class, PredictionApplierHxAuthClient.class, PredictionApplierHxAuthClientIntegrationTest.PredictionApplierHxAuthClientTestConfig.class})
 @EnableAutoConfiguration
 @EnableConfigurationProperties
 @EnableRetry
@@ -98,5 +105,15 @@ class PredictionApplierHxAuthClientIntegrationTest extends HxAuthenticationClien
     protected static void overrideProperties(DynamicPropertyRegistry registry)
     {
         AuthUtils.overrideAuthProperties(registry, ACS_MOCK.getBaseUrl(), "alfresco");
+    }
+
+    @TestConfiguration
+    public static class PredictionApplierHxAuthClientTestConfig
+    {
+        @Bean
+        public NodesApiProperties nodesApiProperties()
+        {
+            return new NodesApiProperties("http://localhost:8002", "dummy-user", "dummy-password", null);
+        }
     }
 }

--- a/prediction-applier/src/integration-test/java/org/alfresco/hxi_connector/prediction_applier/adapters/auth/PredictionApplierHxAuthClientIntegrationTest.java
+++ b/prediction-applier/src/integration-test/java/org/alfresco/hxi_connector/prediction_applier/adapters/auth/PredictionApplierHxAuthClientIntegrationTest.java
@@ -25,23 +25,78 @@
  */
 package org.alfresco.hxi_connector.prediction_applier.adapters.auth;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.givenThat;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.apache.hc.core5.http.ContentType.APPLICATION_FORM_URLENCODED;
+import static org.apache.hc.core5.http.HttpHeaders.HOST;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.then;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.matching.EqualToPattern;
+import org.apache.camel.Exchange;
+import org.apache.hc.core5.http.HttpStatus;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.wiremock.integrations.testcontainers.WireMockContainer;
 
+import org.alfresco.hxi_connector.common.adapters.auth.AuthenticationResult;
 import org.alfresco.hxi_connector.common.adapters.auth.HxAuthenticationClientTest;
-import org.alfresco.hxi_connector.prediction_applier.config.HxInsightProperties;
-import org.alfresco.hxi_connector.prediction_applier.config.SecurityConfig;
+import org.alfresco.hxi_connector.common.adapters.auth.util.AuthUtils;
+import org.alfresco.hxi_connector.common.test.docker.util.DockerContainers;
 
-@SpringBootTest(
-        classes = {HxInsightProperties.class, SecurityConfig.class},
-        properties = "logging.level.org.alfresco=DEBUG")
+@SpringBootTest(properties = "logging.level.org.alfresco=DEBUG")
 @EnableAutoConfiguration
 @EnableConfigurationProperties
 @EnableRetry
 @Testcontainers
 @SuppressWarnings("PMD.TestClassWithoutTestCases")
 class PredictionApplierHxAuthClientIntegrationTest extends HxAuthenticationClientTest
-{}
+{
+    @Container
+    private static final WireMockContainer ACS_MOCK = DockerContainers.createWireMockContainer();
+
+    @Test
+    protected void testAuthorize_alfresco()
+    {
+        // given
+        WireMock.configureFor(ACS_MOCK.getHost(), ACS_MOCK.getPort());
+        givenThat(post(AuthUtils.TOKEN_PATH)
+                .willReturn(aResponse()
+                        .withStatus(HttpStatus.SC_OK)
+                        .withBody(AuthUtils.createAuthResponseBody())));
+
+        // when
+        String clientRegistrationId = "alfresco";
+        AuthenticationResult authenticationResult = authenticationClient.authenticate(clientRegistrationId);
+
+        // then
+        then(authenticationClient).should().authenticate(clientRegistrationId);
+        String authRequestBody = AuthUtils.createAuthRequestBody();
+        WireMock.verify(postRequestedFor(urlPathEqualTo(AuthUtils.TOKEN_PATH))
+                .withHeader(HOST, new EqualToPattern(ACS_MOCK.getHost() + ":" + ACS_MOCK.getPort()))
+                .withHeader(Exchange.CONTENT_TYPE, new EqualToPattern(APPLICATION_FORM_URLENCODED.getMimeType()))
+                .withHeader(Exchange.CONTENT_LENGTH, new EqualToPattern(String.valueOf(authRequestBody.getBytes(UTF_8).length)))
+                .withRequestBody(new EqualToPattern(authRequestBody)));
+        AuthenticationResult expectedAuthenticationResult = AuthUtils.createExpectedAuthResult();
+        assertThat(authenticationResult).isEqualTo(expectedAuthenticationResult);
+    }
+
+    @DynamicPropertySource
+    protected static void overrideProperties(DynamicPropertyRegistry registry)
+    {
+        AuthUtils.overrideAuthProperties(registry, ACS_MOCK.getBaseUrl(), "alfresco");
+    }
+}

--- a/prediction-applier/src/main/java/org/alfresco/hxi_connector/prediction_applier/auth/PredictionApplierHxAuthClient.java
+++ b/prediction-applier/src/main/java/org/alfresco/hxi_connector/prediction_applier/auth/PredictionApplierHxAuthClient.java
@@ -25,21 +25,35 @@
  */
 package org.alfresco.hxi_connector.prediction_applier.auth;
 
+import java.util.Objects;
+
 import org.apache.camel.CamelContext;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.stereotype.Component;
 
 import org.alfresco.hxi_connector.common.adapters.auth.AuthenticationResult;
 import org.alfresco.hxi_connector.common.adapters.auth.HxAuthenticationClient;
+import org.alfresco.hxi_connector.common.adapters.auth.TokenRequest;
 import org.alfresco.hxi_connector.common.exception.EndpointServerErrorException;
 import org.alfresco.hxi_connector.prediction_applier.config.HxInsightProperties;
+import org.alfresco.hxi_connector.prediction_applier.config.NodesApiProperties;
 
+@Component
 public class PredictionApplierHxAuthClient extends HxAuthenticationClient
 {
-    public PredictionApplierHxAuthClient(CamelContext camelContext, HxInsightProperties hxInsightProperties)
+    private final OAuth2ClientProperties oAuth2ClientProperties;
+    private final NodesApiProperties nodesApiProperties;
+
+    public PredictionApplierHxAuthClient(CamelContext camelContext, HxInsightProperties hxInsightProperties,
+            OAuth2ClientProperties oAuth2ClientProperties, NodesApiProperties nodesApiProperties)
     {
         super(camelContext, hxInsightProperties.hylandExperience().authentication().retry());
+        this.oAuth2ClientProperties = oAuth2ClientProperties;
+        this.nodesApiProperties = nodesApiProperties;
     }
 
     @Retryable(retryFor = EndpointServerErrorException.class,
@@ -50,5 +64,45 @@ public class PredictionApplierHxAuthClient extends HxAuthenticationClient
     public AuthenticationResult authenticate(String tokenUri, ClientRegistration clientRegistration)
     {
         return super.authenticate(tokenUri, clientRegistration);
+    }
+
+    @Retryable(retryFor = EndpointServerErrorException.class,
+            maxAttemptsExpression = "#{@hxInsightProperties.hylandExperience.authentication.retry.attempts}",
+            backoff = @Backoff(delayExpression = "#{@hxInsightProperties.hylandExperience.authentication.retry.initialDelay}",
+                    multiplierExpression = "#{@hxInsightProperties.hylandExperience.authentication.retry.delayMultiplier}"))
+    @Override
+    public AuthenticationResult authenticate(String clientRegistrationId)
+    {
+        OAuth2ClientProperties.Provider provider = oAuth2ClientProperties.getProvider().get(clientRegistrationId);
+        Objects.requireNonNull(provider, "Auth Provider not found for client registration id: " + clientRegistrationId);
+        OAuth2ClientProperties.Registration registration = oAuth2ClientProperties.getRegistration().get(clientRegistrationId);
+        Objects.requireNonNull(registration, "Auth Registration not found for client registration id: " + clientRegistrationId);
+        String tokenUri = provider.getTokenUri();
+        ClientRegistration clientRegistration = ClientRegistration.withRegistrationId(clientRegistrationId)
+                .tokenUri(tokenUri)
+                .authorizationGrantType(new AuthorizationGrantType(registration.getAuthorizationGrantType()))
+                .clientId(registration.getClientId())
+                .clientSecret(registration.getClientSecret())
+                .scope(registration.getScope())
+                .build();
+        return super.authenticate(tokenUri, clientRegistration);
+    }
+
+    @Override
+    protected String createEncodedBody(ClientRegistration clientRegistration)
+    {
+        if (AuthorizationGrantType.PASSWORD.getValue().equals(clientRegistration.getAuthorizationGrantType().getValue()))
+        {
+            return TokenRequest.builder()
+                    .grantType(clientRegistration.getAuthorizationGrantType().getValue())
+                    .clientId(clientRegistration.getClientId())
+                    .scope(clientRegistration.getScopes())
+                    .username(nodesApiProperties.username())
+                    .password(nodesApiProperties.password())
+                    .build()
+                    .getTokenRequestBody();
+
+        }
+        return super.createEncodedBody(clientRegistration);
     }
 }

--- a/prediction-applier/src/main/java/org/alfresco/hxi_connector/prediction_applier/config/SecurityConfig.java
+++ b/prediction-applier/src/main/java/org/alfresco/hxi_connector/prediction_applier/config/SecurityConfig.java
@@ -41,11 +41,11 @@ import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 
+import org.alfresco.hxi_connector.common.adapters.auth.AccessTokenProvider;
 import org.alfresco.hxi_connector.common.adapters.auth.AuthenticationClient;
 import org.alfresco.hxi_connector.common.adapters.auth.AuthenticationService;
-import org.alfresco.hxi_connector.common.adapters.auth.HxAuthenticationClient;
+import org.alfresco.hxi_connector.common.adapters.auth.DefaultAccessTokenProvider;
 import org.alfresco.hxi_connector.common.adapters.auth.HxOAuth2AuthenticationProvider;
-import org.alfresco.hxi_connector.prediction_applier.auth.PredictionApplierHxAuthClient;
 
 @Configuration
 @EnableMethodSecurity
@@ -78,8 +78,8 @@ public class SecurityConfig
     }
 
     @Bean
-    public HxAuthenticationClient predictionApplierHxAuthClient(CamelContext camelContext, HxInsightProperties hxInsightProperties)
+    public AccessTokenProvider defaultAccessTokenProvider(CamelContext camelContext, AuthenticationClient predictionApplierHxAuthClient)
     {
-        return new PredictionApplierHxAuthClient(camelContext, hxInsightProperties);
+        return new DefaultAccessTokenProvider(camelContext, predictionApplierHxAuthClient);
     }
 }

--- a/prediction-applier/src/main/java/org/alfresco/hxi_connector/prediction_applier/hx_insight/PredictionCollector.java
+++ b/prediction-applier/src/main/java/org/alfresco/hxi_connector/prediction_applier/hx_insight/PredictionCollector.java
@@ -84,6 +84,7 @@ public class PredictionCollector extends RouteBuilder
 
         from(insightPredictionsProperties.collectorTimerEndpoint())
             .routeId(TIMER_ROUTE_ID)
+            .delay(5000)
             .choice()
             .when(this::isProcessingPending)
                 .log(DEBUG, log, "Prediction processing is pending, no need to trigger it")

--- a/prediction-applier/src/main/java/org/alfresco/hxi_connector/prediction_applier/hx_insight/PredictionCollector.java
+++ b/prediction-applier/src/main/java/org/alfresco/hxi_connector/prediction_applier/hx_insight/PredictionCollector.java
@@ -84,7 +84,6 @@ public class PredictionCollector extends RouteBuilder
 
         from(insightPredictionsProperties.collectorTimerEndpoint())
             .routeId(TIMER_ROUTE_ID)
-            .delay(5000)
             .choice()
             .when(this::isProcessingPending)
                 .log(DEBUG, log, "Prediction processing is pending, no need to trigger it")

--- a/prediction-applier/src/main/java/org/alfresco/hxi_connector/prediction_applier/repository/NodesClient.java
+++ b/prediction-applier/src/main/java/org/alfresco/hxi_connector/prediction_applier/repository/NodesClient.java
@@ -80,7 +80,7 @@ public class NodesClient extends RouteBuilder
 
     @Override
     @SuppressWarnings("unchecked")
-    public void configure() throws Exception
+    public void configure()
     {
         // @formatter:off
         onException(RETRY_REASONS.toArray(Class[]::new))
@@ -120,6 +120,7 @@ public class NodesClient extends RouteBuilder
         // @formatter:on
     }
 
+    @SuppressWarnings("PMD.UnusedPrivateMethod")
     private void setAuthorizationHeader(Exchange exchange)
     {
         if (oAuth2ClientProperties.getProvider().containsKey("alfresco"))

--- a/prediction-applier/src/main/java/org/alfresco/hxi_connector/prediction_applier/repository/NodesClient.java
+++ b/prediction-applier/src/main/java/org/alfresco/hxi_connector/prediction_applier/repository/NodesClient.java
@@ -25,10 +25,14 @@
  */
 package org.alfresco.hxi_connector.prediction_applier.repository;
 
+import static org.apache.camel.Exchange.HTTP_METHOD;
 import static org.apache.camel.Exchange.HTTP_RESPONSE_CODE;
+import static org.apache.camel.component.http.HttpMethods.PUT;
 import static org.apache.hc.core5.http.HttpStatus.SC_CREATED;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 import java.net.UnknownHostException;
+import java.util.Base64;
 import java.util.Set;
 
 import com.fasterxml.jackson.core.io.JsonEOFException;
@@ -41,8 +45,10 @@ import org.apache.camel.model.dataformat.JsonLibrary;
 import org.apache.hc.client5.http.HttpHostConnectException;
 import org.apache.hc.core5.http.MalformedChunkCodingException;
 import org.apache.hc.core5.http.NoHttpResponseException;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
 import org.springframework.stereotype.Component;
 
+import org.alfresco.hxi_connector.common.adapters.auth.AccessTokenProvider;
 import org.alfresco.hxi_connector.common.exception.EndpointServerErrorException;
 import org.alfresco.hxi_connector.common.util.ErrorUtils;
 import org.alfresco.hxi_connector.prediction_applier.config.NodesApiProperties;
@@ -56,7 +62,7 @@ public class NodesClient extends RouteBuilder
     private static final String RETRYABLE_ROUTE = "direct:retryable-" + NodesClient.class.getSimpleName();
     static final String ROUTE_ID = "repository-nodes";
     public static final String NODE_ID_HEADER = "nodeId";
-    private static final String URI_PATTERN = "%s/alfresco/api/-default-/private/hxi/versions/1/nodes/${headers.nodeId}/predictions?httpMethod=POST&authMethod=Basic&authUsername=%s&authPassword=%s&authenticationPreemptive=true&throwExceptionOnFailure=false";
+    private static final String URI_PATTERN = "%s/alfresco/api/-default-/private/hxi/versions/1/nodes/${headers.nodeId}/predictions?throwExceptionOnFailure=false";
     private static final int EXPECTED_STATUS_CODE = SC_CREATED;
     public static final String UNEXPECTED_STATUS_CODE_MESSAGE = "Unexpected response status code - expecting: %d, received: %d";
     private static final Set<Class<? extends Throwable>> RETRY_REASONS = Set.of(
@@ -69,6 +75,8 @@ public class NodesClient extends RouteBuilder
             MalformedChunkCodingException.class);
 
     private final NodesApiProperties nodesApiProperties;
+    private final AccessTokenProvider accessTokenProvider;
+    private final OAuth2ClientProperties oAuth2ClientProperties;
 
     @Override
     @SuppressWarnings("unchecked")
@@ -98,7 +106,9 @@ public class NodesClient extends RouteBuilder
             .id(ROUTE_ID)
             .errorHandler(noErrorHandler())
             .log(LoggingLevel.INFO, log, "Updating node: Headers: ${headers}, Body: ${body}")
-            .toD(URI_PATTERN.formatted(nodesApiProperties.baseUrl(), nodesApiProperties.username(), nodesApiProperties.password()))
+            .setHeader(HTTP_METHOD, constant(PUT))
+            .process(this::setAuthorizationHeader)
+            .toD(URI_PATTERN.formatted(nodesApiProperties.baseUrl()))
             .choice()
             .when(header(HTTP_RESPONSE_CODE).isNotEqualTo(String.valueOf(EXPECTED_STATUS_CODE)))
                 .process(this::throwExceptionOnUnexpectedStatusCode)
@@ -108,6 +118,24 @@ public class NodesClient extends RouteBuilder
             .endChoice()
             .end();
         // @formatter:on
+    }
+
+    private void setAuthorizationHeader(Exchange exchange)
+    {
+        if (oAuth2ClientProperties.getProvider().containsKey("alfresco"))
+        {
+            exchange.getIn().setHeader(AUTHORIZATION, "Bearer " + accessTokenProvider.getAccessToken("alfresco"));
+        }
+        else
+        {
+            exchange.getIn().setHeader(AUTHORIZATION, getBasicAuthenticationHeader());
+        }
+    }
+
+    private String getBasicAuthenticationHeader()
+    {
+        String valueToEncode = nodesApiProperties.username() + ":" + nodesApiProperties.password();
+        return "Basic " + Base64.getEncoder().encodeToString(valueToEncode.getBytes());
     }
 
     @SuppressWarnings("PMD.UnusedPrivateMethod")

--- a/prediction-applier/src/main/resources/application.yml
+++ b/prediction-applier/src/main/resources/application.yml
@@ -11,9 +11,16 @@ spring:
             client-secret: dummy-client-pass
             client-name: ${hyland-experience.authorization.application-name}
             scope: hxp.integrations
+          alfresco:
+            client-id: dummy-client-id
+            client-secret: dummy-client-secret
+            authorization-grant-type: client_credentials
         provider:
           hyland-experience-auth:
             token-uri: http://localhost:8001/token
+          alfresco:
+            token-uri: http://localhost:8002/token
+
 
 camel:
   springboot:


### PR DESCRIPTION
This is a first step of refactoring authentication handling in all modules and it only concerns prediction handler authentication against ACS.
There are some parts of the code which will get changed in future PRs and I'll try to explain by commenting in this PR.