### PR TITLE
ACS-7605: Replacing Spring Security with custom token handling in prediction applier.

### DIFF
--- a/common-authentication/src/main/java/org/alfresco/hxi_connector/common/adapters/auth/DefaultAccessTokenProvider.java
+++ b/common-authentication/src/main/java/org/alfresco/hxi_connector/common/adapters/auth/DefaultAccessTokenProvider.java
@@ -28,7 +28,6 @@ package org.alfresco.hxi_connector.common.adapters.auth;
 import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
@@ -36,6 +35,7 @@ import lombok.RequiredArgsConstructor;
 import org.apache.camel.CamelContext;
 
 import org.alfresco.hxi_connector.common.exception.HxInsightConnectorRuntimeException;
+import org.alfresco.hxi_connector.common.util.EnsureUtils;
 
 @RequiredArgsConstructor
 public class DefaultAccessTokenProvider implements AccessTokenProvider
@@ -56,7 +56,7 @@ public class DefaultAccessTokenProvider implements AccessTokenProvider
             refreshAuthenticationResult(clientRegistrationId);
             authenticationResultEntry = accessTokens.get(clientRegistrationId);
         }
-        Objects.requireNonNull(authenticationResultEntry, "Authentication result is null");
+        EnsureUtils.ensureNonNull(authenticationResultEntry, "Authentication result is null");
         AuthenticationResult authenticationResult = authenticationResultEntry.getKey();
         return authenticationResult.accessToken();
     }

--- a/common-authentication/src/main/java/org/alfresco/hxi_connector/common/adapters/auth/HxAuthenticationClient.java
+++ b/common-authentication/src/main/java/org/alfresco/hxi_connector/common/adapters/auth/HxAuthenticationClient.java
@@ -36,7 +36,6 @@ import static org.alfresco.hxi_connector.common.util.ErrorUtils.UNEXPECTED_STATU
 
 import java.net.URI;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 import lombok.RequiredArgsConstructor;
@@ -50,6 +49,7 @@ import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2Clien
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 
 import org.alfresco.hxi_connector.common.config.properties.Retry;
+import org.alfresco.hxi_connector.common.util.EnsureUtils;
 import org.alfresco.hxi_connector.common.util.ErrorUtils;
 
 @RequiredArgsConstructor
@@ -103,7 +103,7 @@ public class HxAuthenticationClient extends RouteBuilder implements Authenticati
     {
         String body = createEncodedBody(clientRegistrationId);
         OAuth2ClientProperties.Provider provider = oAuth2ClientProperties.getProvider().get(clientRegistrationId);
-        Objects.requireNonNull(provider, "Auth Provider not found for client registration id: " + clientRegistrationId);
+        EnsureUtils.ensureNonNull(provider, "Auth Provider not found for client registration id: " + clientRegistrationId);
         String tokenUri = provider.getTokenUri();
         log.atDebug().log("Authentication :: sending token request for {} client registration", clientRegistrationId);
 
@@ -141,7 +141,7 @@ public class HxAuthenticationClient extends RouteBuilder implements Authenticati
     protected String createEncodedBody(String clientRegistrationId)
     {
         OAuth2ClientProperties.Registration registration = oAuth2ClientProperties.getRegistration().get(clientRegistrationId);
-        Objects.requireNonNull(registration, "Auth Registration not found for client registration id: " + clientRegistrationId);
+        EnsureUtils.ensureNonNull(registration, "Auth Registration not found for client registration id: " + clientRegistrationId);
         return TokenRequest.builder()
                 .clientId(registration.getClientId())
                 .grantType(registration.getAuthorizationGrantType())

--- a/common-authentication/src/main/java/org/alfresco/hxi_connector/common/adapters/auth/HxAuthenticationClient.java
+++ b/common-authentication/src/main/java/org/alfresco/hxi_connector/common/adapters/auth/HxAuthenticationClient.java
@@ -36,6 +36,7 @@ import static org.alfresco.hxi_connector.common.util.ErrorUtils.UNEXPECTED_STATU
 
 import java.net.URI;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import lombok.RequiredArgsConstructor;
@@ -45,6 +46,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.LoggingLevel;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.dataformat.JsonLibrary;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 
 import org.alfresco.hxi_connector.common.config.properties.Retry;
@@ -61,6 +63,7 @@ public class HxAuthenticationClient extends RouteBuilder implements Authenticati
 
     private final CamelContext camelContext;
     private final Retry retryProperties;
+    private final OAuth2ClientProperties oAuth2ClientProperties;
 
     @Override
     public void configure()
@@ -91,8 +94,25 @@ public class HxAuthenticationClient extends RouteBuilder implements Authenticati
     public AuthenticationResult authenticate(String tokenUri, ClientRegistration clientRegistration)
     {
         String body = createEncodedBody(clientRegistration);
-        int contentLength = body.getBytes(UTF_8).length;
+        log.atDebug().log("Authentication :: sending token request for {} client registration", clientRegistration.getRegistrationId());
+        return sendRequest(tokenUri, body);
+    }
 
+    @Override
+    public AuthenticationResult authenticate(String clientRegistrationId)
+    {
+        String body = createEncodedBody(clientRegistrationId);
+        OAuth2ClientProperties.Provider provider = oAuth2ClientProperties.getProvider().get(clientRegistrationId);
+        Objects.requireNonNull(provider, "Auth Provider not found for client registration id: " + clientRegistrationId);
+        String tokenUri = provider.getTokenUri();
+        log.atDebug().log("Authentication :: sending token request for {} client registration", clientRegistrationId);
+
+        return sendRequest(tokenUri, body);
+    }
+
+    private AuthenticationResult sendRequest(String tokenUri, String body)
+    {
+        int contentLength = body.getBytes(UTF_8).length;
         return camelContext.createFluentProducerTemplate()
                 .to(LOCAL_AUTH_ENDPOINT)
                 .withProcessor(exchange -> {
@@ -107,13 +127,26 @@ public class HxAuthenticationClient extends RouteBuilder implements Authenticati
                 .request(AuthenticationResult.class);
     }
 
-    protected String createEncodedBody(ClientRegistration clientRegistration)
+    private String createEncodedBody(ClientRegistration clientRegistration)
     {
         return TokenRequest.builder()
                 .clientId(clientRegistration.getClientId())
                 .grantType(clientRegistration.getAuthorizationGrantType().getValue())
                 .clientSecret(clientRegistration.getClientSecret())
                 .scope(clientRegistration.getScopes())
+                .build()
+                .getTokenRequestBody();
+    }
+
+    protected String createEncodedBody(String clientRegistrationId)
+    {
+        OAuth2ClientProperties.Registration registration = oAuth2ClientProperties.getRegistration().get(clientRegistrationId);
+        Objects.requireNonNull(registration, "Auth Registration not found for client registration id: " + clientRegistrationId);
+        return TokenRequest.builder()
+                .clientId(registration.getClientId())
+                .grantType(registration.getAuthorizationGrantType())
+                .clientSecret(registration.getClientSecret())
+                .scope(registration.getScope())
                 .build()
                 .getTokenRequestBody();
     }

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/auth/LiveIngesterHxAuthClient.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/auth/LiveIngesterHxAuthClient.java
@@ -26,6 +26,7 @@
 package org.alfresco.hxi_connector.live_ingester.adapters.auth;
 
 import org.apache.camel.CamelContext;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
@@ -38,9 +39,9 @@ import org.alfresco.hxi_connector.live_ingester.adapters.config.IntegrationPrope
 public class LiveIngesterHxAuthClient extends HxAuthenticationClient
 {
 
-    public LiveIngesterHxAuthClient(CamelContext camelContext, IntegrationProperties integrationProperties)
+    public LiveIngesterHxAuthClient(CamelContext camelContext, IntegrationProperties integrationProperties, OAuth2ClientProperties oAuth2ClientProperties)
     {
-        super(camelContext, integrationProperties.hylandExperience().authentication().retry());
+        super(camelContext, integrationProperties.hylandExperience().authentication().retry(), oAuth2ClientProperties);
     }
 
     @Retryable(retryFor = EndpointServerErrorException.class,

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/config/SecurityConfig.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/config/SecurityConfig.java
@@ -78,8 +78,8 @@ public class SecurityConfig
     }
 
     @Bean
-    public HxAuthenticationClient liveIngesterHxAuthClient(CamelContext camelContext, IntegrationProperties integrationProperties)
+    public HxAuthenticationClient liveIngesterHxAuthClient(CamelContext camelContext, IntegrationProperties integrationProperties, OAuth2ClientProperties oAuth2ClientProperties)
     {
-        return new LiveIngesterHxAuthClient(camelContext, integrationProperties);
+        return new LiveIngesterHxAuthClient(camelContext, integrationProperties, oAuth2ClientProperties);
     }
 }

--- a/prediction-applier/src/main/java/org/alfresco/hxi_connector/prediction_applier/auth/PredictionApplierHxAuthClient.java
+++ b/prediction-applier/src/main/java/org/alfresco/hxi_connector/prediction_applier/auth/PredictionApplierHxAuthClient.java
@@ -25,8 +25,6 @@
  */
 package org.alfresco.hxi_connector.prediction_applier.auth;
 
-import java.util.Objects;
-
 import org.apache.camel.CamelContext;
 import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
 import org.springframework.retry.annotation.Backoff;
@@ -39,6 +37,7 @@ import org.alfresco.hxi_connector.common.adapters.auth.AuthenticationResult;
 import org.alfresco.hxi_connector.common.adapters.auth.HxAuthenticationClient;
 import org.alfresco.hxi_connector.common.adapters.auth.TokenRequest;
 import org.alfresco.hxi_connector.common.exception.EndpointServerErrorException;
+import org.alfresco.hxi_connector.common.util.EnsureUtils;
 import org.alfresco.hxi_connector.prediction_applier.config.HxInsightProperties;
 import org.alfresco.hxi_connector.prediction_applier.config.NodesApiProperties;
 
@@ -80,7 +79,7 @@ public class PredictionApplierHxAuthClient extends HxAuthenticationClient
     protected String createEncodedBody(String clientRegistrationId)
     {
         OAuth2ClientProperties.Registration registration = oAuth2ClientProperties.getRegistration().get(clientRegistrationId);
-        Objects.requireNonNull(registration, "Auth Registration not found for client registration id: " + clientRegistrationId);
+        EnsureUtils.ensureNonNull(registration, "Auth Registration not found for client registration id: " + clientRegistrationId);
         if (AuthorizationGrantType.PASSWORD.getValue().equals(registration.getAuthorizationGrantType()))
         {
             return TokenRequest.builder()

--- a/prediction-applier/src/main/java/org/alfresco/hxi_connector/prediction_applier/auth/PredictionApplierHxAuthClient.java
+++ b/prediction-applier/src/main/java/org/alfresco/hxi_connector/prediction_applier/auth/PredictionApplierHxAuthClient.java
@@ -31,6 +31,7 @@ import org.apache.camel.CamelContext;
 import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.stereotype.Component;
 
@@ -53,6 +54,16 @@ public class PredictionApplierHxAuthClient extends HxAuthenticationClient
         super(camelContext, hxInsightProperties.hylandExperience().authentication().retry(), oAuth2ClientProperties);
         this.oAuth2ClientProperties = oAuth2ClientProperties;
         this.nodesApiProperties = nodesApiProperties;
+    }
+
+    @Retryable(retryFor = EndpointServerErrorException.class,
+            maxAttemptsExpression = "#{@hxInsightProperties.hylandExperience.authentication.retry.attempts}",
+            backoff = @Backoff(delayExpression = "#{@hxInsightProperties.hylandExperience.authentication.retry.initialDelay}",
+                    multiplierExpression = "#{@hxInsightProperties.hylandExperience.authentication.retry.delayMultiplier}"))
+    @Override
+    public AuthenticationResult authenticate(String tokenUri, ClientRegistration clientRegistration)
+    {
+        return super.authenticate(tokenUri, clientRegistration);
     }
 
     @Retryable(retryFor = EndpointServerErrorException.class,

--- a/prediction-applier/src/main/java/org/alfresco/hxi_connector/prediction_applier/config/SecurityConfig.java
+++ b/prediction-applier/src/main/java/org/alfresco/hxi_connector/prediction_applier/config/SecurityConfig.java
@@ -25,27 +25,18 @@
  */
 package org.alfresco.hxi_connector.prediction_applier.config;
 
-import java.util.List;
-
 import org.apache.camel.CamelContext;
 import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.DependsOn;
 import org.springframework.retry.annotation.EnableRetry;
-import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.EnableScheduling;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.AuthenticationProvider;
-import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 
 import org.alfresco.hxi_connector.common.adapters.auth.AccessTokenProvider;
 import org.alfresco.hxi_connector.common.adapters.auth.AuthenticationClient;
-import org.alfresco.hxi_connector.common.adapters.auth.AuthenticationService;
 import org.alfresco.hxi_connector.common.adapters.auth.DefaultAccessTokenProvider;
-import org.alfresco.hxi_connector.common.adapters.auth.HxOAuth2AuthenticationProvider;
 
 @Configuration
 @EnableMethodSecurity
@@ -54,29 +45,6 @@ import org.alfresco.hxi_connector.common.adapters.auth.HxOAuth2AuthenticationPro
 @EnableConfigurationProperties(OAuth2ClientProperties.class)
 public class SecurityConfig
 {
-
-    @Bean
-    @DependsOn("predictionApplierHxAuthClient")
-    public AuthenticationProvider hxAuthenticationProvider(OAuth2ClientProperties oAuth2ClientProperties, AuthenticationClient predictionApplierHxAuthClient)
-    {
-        return new HxOAuth2AuthenticationProvider(oAuth2ClientProperties, predictionApplierHxAuthClient);
-    }
-
-    @Bean
-    public AuthenticationManager authenticationManager(List<AuthenticationProvider> authenticationProviders)
-    {
-        return new ProviderManager(authenticationProviders);
-    }
-
-    @Bean
-    @DependsOn("authenticationManager")
-    public AuthenticationService authenticationService(OAuth2ClientProperties oAuth2ClientProperties, HxInsightProperties hxInsightProperties,
-            AuthenticationManager authenticationManager, TaskScheduler taskScheduler, CamelContext camelContext)
-    {
-        return new AuthenticationService(oAuth2ClientProperties, hxInsightProperties.hylandExperience().authorization(), hxInsightProperties.hylandExperience().authentication(),
-                authenticationManager, taskScheduler, camelContext);
-    }
-
     @Bean
     public AccessTokenProvider defaultAccessTokenProvider(CamelContext camelContext, AuthenticationClient predictionApplierHxAuthClient)
     {

--- a/prediction-applier/src/main/java/org/alfresco/hxi_connector/prediction_applier/hx_insight/PredictionCollector.java
+++ b/prediction-applier/src/main/java/org/alfresco/hxi_connector/prediction_applier/hx_insight/PredictionCollector.java
@@ -28,6 +28,8 @@ package org.alfresco.hxi_connector.prediction_applier.hx_insight;
 import static org.apache.camel.LoggingLevel.DEBUG;
 import static org.apache.camel.LoggingLevel.TRACE;
 
+import static org.alfresco.hxi_connector.common.adapters.auth.AuthSupport.ENVIRONMENT_KEY_ATTRIBUTE_KEY;
+
 import java.util.Collection;
 import java.util.Objects;
 
@@ -37,11 +39,13 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jackson.JacksonDataFormat;
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
-import org.alfresco.hxi_connector.common.adapters.auth.AuthSupport;
+import org.alfresco.hxi_connector.common.adapters.auth.AccessTokenProvider;
+import org.alfresco.hxi_connector.prediction_applier.config.HxInsightProperties;
 import org.alfresco.hxi_connector.prediction_applier.config.InsightPredictionsProperties;
 import org.alfresco.hxi_connector.prediction_applier.model.prediction.PredictionEntry;
 import org.alfresco.hxi_connector.prediction_applier.util.LinkedListJacksonDataFormat;
@@ -58,6 +62,8 @@ public class PredictionCollector extends RouteBuilder
     private static final String IS_PREDICTION_PROCESSING_PENDING_KEY = "is-prediction-processing-pending";
 
     private final InsightPredictionsProperties insightPredictionsProperties;
+    private final AccessTokenProvider accessTokenProvider;
+    private final HxInsightProperties hxInsightProperties;
 
     // @formatter:off
     /**
@@ -97,7 +103,7 @@ public class PredictionCollector extends RouteBuilder
         from(DIRECT_ENDPOINT)
             .routeId(COLLECTOR_ROUTE_ID)
             .process(setProcessingPending(true))
-            .process(exchange -> AuthSupport.setAuthorizationToken(securityContext, exchange))
+            .process(this::setAuthorizationHeaders)
             .loopDoWhile(bodyAs(Collection.class).method("isEmpty").isEqualTo(false))
                 .log(DEBUG, log, "Fetching predictions")
                 .to(insightPredictionsProperties.sourceEndpoint())
@@ -125,5 +131,13 @@ public class PredictionCollector extends RouteBuilder
     private Processor setProcessingPending(boolean isProcessingPending)
     {
         return exchange -> getContext().getRegistry().bind(IS_PREDICTION_PROCESSING_PENDING_KEY, isProcessingPending);
+    }
+
+    private void setAuthorizationHeaders(Exchange exchange)
+    {
+        final String token = "Bearer " + accessTokenProvider.getAccessToken("hyland-experience-auth");
+        String environmentKey = hxInsightProperties.hylandExperience().authorization().environmentKey();
+        exchange.getIn().setHeader(HttpHeaders.AUTHORIZATION, token);
+        exchange.getIn().setHeader(ENVIRONMENT_KEY_ATTRIBUTE_KEY, environmentKey);
     }
 }

--- a/prediction-applier/src/main/java/org/alfresco/hxi_connector/prediction_applier/hx_insight/PredictionCollector.java
+++ b/prediction-applier/src/main/java/org/alfresco/hxi_connector/prediction_applier/hx_insight/PredictionCollector.java
@@ -40,8 +40,6 @@ import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.jackson.JacksonDataFormat;
 import org.springframework.http.HttpHeaders;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 import org.alfresco.hxi_connector.common.adapters.auth.AccessTokenProvider;
@@ -99,7 +97,6 @@ public class PredictionCollector extends RouteBuilder
             .end()
             .end();
 
-        SecurityContext securityContext = SecurityContextHolder.getContext();
         from(DIRECT_ENDPOINT)
             .routeId(COLLECTOR_ROUTE_ID)
             .process(setProcessingPending(true))

--- a/prediction-applier/src/main/java/org/alfresco/hxi_connector/prediction_applier/repository/NodesClient.java
+++ b/prediction-applier/src/main/java/org/alfresco/hxi_connector/prediction_applier/repository/NodesClient.java
@@ -123,7 +123,7 @@ public class NodesClient extends RouteBuilder
     @SuppressWarnings("PMD.UnusedPrivateMethod")
     private void setAuthorizationHeader(Exchange exchange)
     {
-        boolean isAlfrescoBasicAuth = oAuth2ClientProperties.getProvider().containsKey("alfresco");
+        boolean isAlfrescoBasicAuth = !oAuth2ClientProperties.getProvider().containsKey("alfresco");
         String authHeader = isAlfrescoBasicAuth ? getBasicAuthenticationHeader() : getAlfrescoAccessTokenHeader();
 
         exchange.getIn().setHeader(AUTHORIZATION, authHeader);

--- a/prediction-applier/src/main/java/org/alfresco/hxi_connector/prediction_applier/repository/NodesClient.java
+++ b/prediction-applier/src/main/java/org/alfresco/hxi_connector/prediction_applier/repository/NodesClient.java
@@ -123,14 +123,9 @@ public class NodesClient extends RouteBuilder
     @SuppressWarnings("PMD.UnusedPrivateMethod")
     private void setAuthorizationHeader(Exchange exchange)
     {
-        if (oAuth2ClientProperties.getProvider().containsKey("alfresco"))
-        {
-            exchange.getIn().setHeader(AUTHORIZATION, "Bearer " + accessTokenProvider.getAccessToken("alfresco"));
-        }
-        else
-        {
-            exchange.getIn().setHeader(AUTHORIZATION, getBasicAuthenticationHeader());
-        }
+        final String token = oAuth2ClientProperties.getProvider().containsKey("alfresco") ? "Bearer " + accessTokenProvider.getAccessToken("alfresco") : getBasicAuthenticationHeader();
+
+        exchange.getIn().setHeader(AUTHORIZATION, token);
     }
 
     private String getBasicAuthenticationHeader()

--- a/prediction-applier/src/main/java/org/alfresco/hxi_connector/prediction_applier/repository/NodesClient.java
+++ b/prediction-applier/src/main/java/org/alfresco/hxi_connector/prediction_applier/repository/NodesClient.java
@@ -123,9 +123,15 @@ public class NodesClient extends RouteBuilder
     @SuppressWarnings("PMD.UnusedPrivateMethod")
     private void setAuthorizationHeader(Exchange exchange)
     {
-        final String token = oAuth2ClientProperties.getProvider().containsKey("alfresco") ? "Bearer " + accessTokenProvider.getAccessToken("alfresco") : getBasicAuthenticationHeader();
+        boolean isAlfrescoBasicAuth = oAuth2ClientProperties.getProvider().containsKey("alfresco");
+        String authHeader = isAlfrescoBasicAuth ? getBasicAuthenticationHeader() : getAlfrescoAccessTokenHeader();
 
-        exchange.getIn().setHeader(AUTHORIZATION, token);
+        exchange.getIn().setHeader(AUTHORIZATION, authHeader);
+    }
+
+    private String getAlfrescoAccessTokenHeader()
+    {
+        return "Bearer " + accessTokenProvider.getAccessToken("alfresco");
     }
 
     private String getBasicAuthenticationHeader()

--- a/prediction-applier/src/test/java/org/alfresco/hxi_connector/prediction_applier/repository/NodesClientTest.java
+++ b/prediction-applier/src/test/java/org/alfresco/hxi_connector/prediction_applier/repository/NodesClientTest.java
@@ -32,6 +32,7 @@ import static org.apache.camel.builder.AdviceWith.adviceWith;
 import static org.apache.hc.core5.http.HttpStatus.SC_CREATED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.mock;
 
 import static org.alfresco.hxi_connector.prediction_applier.repository.NodesClient.NODES_DIRECT_ENDPOINT;
 import static org.alfresco.hxi_connector.prediction_applier.repository.NodesClient.ROUTE_ID;
@@ -84,7 +85,7 @@ class NodesClientTest
         camelContext = new DefaultCamelContext();
         OAuth2ClientProperties dummyOauth2Properties = createDummyOauth2Properties();
         Retry dummyRetryProperties = new Retry(RETRY_ATTEMPTS, 0, 1, emptySet());
-        AuthenticationClient dummyAuthClient = new HxAuthenticationClient(camelContext, dummyRetryProperties);
+        AuthenticationClient dummyAuthClient = new HxAuthenticationClient(camelContext, dummyRetryProperties, mock());
         AccessTokenProvider dummyAccessTokenProvider = new DefaultAccessTokenProvider(camelContext, dummyAuthClient);
         NodesClient nodesClient = new NodesClient(createNodesApiProperties(), dummyAccessTokenProvider, dummyOauth2Properties);
         camelContext.addRoutes(nodesClient);


### PR DESCRIPTION
The second part of authentication refactoring - removes Spring Security from prediction applier.
Final part (removal of Spring Security in live ingester) will come as the next PR.