### PR TITLE
Fix compilation issues when skipping tests

### DIFF
--- a/live-ingester/pom.xml
+++ b/live-ingester/pom.xml
@@ -122,19 +122,19 @@
 
     <profiles>
         <profile>
-        <id>test</id>
-        <activation>
-            <activeByDefault>true</activeByDefault>
-        </activation>
-        <dependencies>
-            <dependency>
-                <groupId>org.alfresco</groupId>
-                <artifactId>alfresco-hxinsight-connector-common-authentication</artifactId>
-                <version>${project.parent.version}</version>
-                <type>test-jar</type>
-                <scope>test</scope>
-            </dependency>
-        </dependencies>
+            <id>test</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.alfresco</groupId>
+                    <artifactId>alfresco-hxinsight-connector-common-authentication</artifactId>
+                    <version>${project.parent.version}</version>
+                    <type>test-jar</type>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
     </profiles>
 </project>

--- a/live-ingester/pom.xml
+++ b/live-ingester/pom.xml
@@ -84,13 +84,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.alfresco</groupId>
-            <artifactId>alfresco-hxinsight-connector-common-authentication</artifactId>
-            <version>${project.parent.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
@@ -126,4 +119,22 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+        <id>test</id>
+        <activation>
+            <activeByDefault>true</activeByDefault>
+        </activation>
+        <dependencies>
+            <dependency>
+                <groupId>org.alfresco</groupId>
+                <artifactId>alfresco-hxinsight-connector-common-authentication</artifactId>
+                <version>${project.parent.version}</version>
+                <type>test-jar</type>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/prediction-applier/pom.xml
+++ b/prediction-applier/pom.xml
@@ -70,13 +70,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.alfresco</groupId>
-            <artifactId>alfresco-hxinsight-connector-common-authentication</artifactId>
-            <version>${project.parent.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
             <scope>test</scope>
@@ -98,4 +91,21 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+        <id>test</id>
+        <activation>
+            <activeByDefault>true</activeByDefault>
+        </activation>
+        <dependencies>
+            <dependency>
+                <groupId>org.alfresco</groupId>
+                <artifactId>alfresco-hxinsight-connector-common-authentication</artifactId>
+                <version>${project.parent.version}</version>
+                <type>test-jar</type>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/prediction-applier/pom.xml
+++ b/prediction-applier/pom.xml
@@ -93,19 +93,19 @@
 
     <profiles>
         <profile>
-        <id>test</id>
-        <activation>
-            <activeByDefault>true</activeByDefault>
-        </activation>
-        <dependencies>
-            <dependency>
-                <groupId>org.alfresco</groupId>
-                <artifactId>alfresco-hxinsight-connector-common-authentication</artifactId>
-                <version>${project.parent.version}</version>
-                <type>test-jar</type>
-                <scope>test</scope>
-            </dependency>
-        </dependencies>
+            <id>test</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.alfresco</groupId>
+                    <artifactId>alfresco-hxinsight-connector-common-authentication</artifactId>
+                    <version>${project.parent.version}</version>
+                    <type>test-jar</type>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
As per title. Certain dependencies should be excluded when skipping tests, otherwise they won't be found at compilation time causing failures such as 

`
 Error:  Failed to execute goal on project alfresco-hxinsight-connector-live-ingester: Could not resolve dependencies for project org.alfresco:alfresco-hxinsight-connector-live-ingester:jar:1.0.0-SNAPSHOT: Could not find artifact org.alfresco:alfresco-hxinsight-connector-common-authentication:jar:tests:1.0.0-SNAPSHOT in alfresco-internal (https://artifacts.alfresco.com/nexus/content/groups/internal/) -> [Help 1]
`