### PR TITLE
Fix Veracode SCA scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         continue-on-error: true
         with:
           srcclr-api-token: ${{ secrets.SRCCLR_API_TOKEN }}
-          srcclr-install-options: "-Dmaven.test.skip -P !test -pl '!common-test,!e2e-test'"
+          srcclr-install-options: -Dmaven.test.skip -P !test -pl "!common-test,!e2e-test"
 
   pmd_scan:
     name: "PMD Scan"


### PR DESCRIPTION
Fixing the Veracode SCA scan once again! 🤞

**Context**: the extra single quotes in [this commit](https://github.com/Alfresco/hxinsight-connector/commit/37688eb127796c432abda35fb48cd14a4a7623ac) broke it, but I guess we didn't notice as it fails silently due to the `continue-on-error` option being `true`.

**Successful run after the change**: https://github.com/Alfresco/hxinsight-connector/actions/runs/9501397929/job/26186873098?pr=405 ✅ 