### PR TITLE
Improve local development instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,6 @@ hs_err_pid*
 
 # This file is generated from distribution/src/main/resources/docker-compose-origin/.env
 distribution/src/main/resources/docker-compose/.env
+distribution/src/main/resources/docker-compose/volume
 # This is produced by the maven-shade-plugin
 dependency-reduced-pom.xml

--- a/README.md
+++ b/README.md
@@ -94,19 +94,19 @@ mvn spotless:apply
 
 ### Development Environment
 
-To set up a local developer environment then build the jar, the docker image and finally run the docker-compose environment.
+To set up a local developer environment then build the jar, the docker image and finally run the docker-compose environment:
 
 ```bash
-mvn clean install -Pdistribution && \
+mvn clean install -DskipTests -Pdistribution && \
 ./scripts/ci/buildDockerImages.sh && \
 cd distribution/src/main/resources/docker-compose && \
 docker compose --project-name dev up
 ```
 
-It's also possible to set up local developer environment adjusted to run Live Ingester outside docker container, to do se please run bellow command:
+It's also possible to set up a local developer environment adjusted to run Live Ingester outside docker container, to do so please run the following command:
 
 ```bash
-mvn clean install -Pdistribution && \
+mvn clean install -DskipTests -Pdistribution && \
 ./scripts/ci/buildDockerImages.sh && \
 cd distribution/src/main/resources/docker-compose && \
 docker compose --file docker-compose-ingesterless.yml --project-name dev up


### PR DESCRIPTION
Also added the `distribution/src/main/resources/docker-compose/volume` to the `.gitignore` file as I don't think this is meant to be committed, yet when running the environment locally this seemed to be autogenerated and I guess we don't want people pushing their volumes by mistake.