### PR TITLE
ACS-8115 Differentiate between fields in request and response.

### DIFF
--- a/prediction-applier-extension/src/integration-test/java/org/alfresco/hxi_connector/prediction_applier/rest/api/model/QuestionSerializationTest.java
+++ b/prediction-applier-extension/src/integration-test/java/org/alfresco/hxi_connector/prediction_applier/rest/api/model/QuestionSerializationTest.java
@@ -1,0 +1,88 @@
+/*
+ * #%L
+ * Alfresco HX Insight Connector
+ * %%
+ * Copyright (C) 2023 - 2024 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+package org.alfresco.hxi_connector.prediction_applier.rest.api.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+
+class QuestionSerializationTest
+{
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void shouldThrowWhenQuestionIdSpecified()
+    {
+        // given
+        String questionSerialized = """
+                {
+                    "_questionId": "86553f9b-e382-4a1b-b07d-52adae3e96e8",
+                    "question": "What is the capital of France?"
+                }
+                """;
+
+        // when, then
+        assertThrows(UnrecognizedPropertyException.class, () -> objectMapper.readValue(questionSerialized, Question.class));
+    }
+
+    @Test
+    void shouldThrowWhenQuestionIdSpecified2()
+    {
+        // given
+        String questionSerialized = """
+                {
+                    "questionId": "86553f9b-e382-4a1b-b07d-52adae3e96e8",
+                    "question": "What is the capital of France?"
+                }
+                """;
+
+        // when, then
+        assertThrows(UnrecognizedPropertyException.class, () -> objectMapper.readValue(questionSerialized, Question.class));
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldDeserializeQuestion()
+    {
+        // given
+        String questionSerialized = """
+                {
+                    "question": "What is the capital of France?"
+                }
+                """;
+
+        // when
+        Question question = objectMapper.readValue(questionSerialized, Question.class);
+
+        // then
+        assertEquals("What is the capital of France?", question.getQuestion());
+    }
+}

--- a/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/QuestionsEntityResource.java
+++ b/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/QuestionsEntityResource.java
@@ -54,8 +54,8 @@ public class QuestionsEntityResource implements EntityResourceAction.Create<Ques
 
         log.info("Received question: {}", question);
 
-        question.setQuestionId("questionId");
+        Question returnedQuestion = new Question("questionId", question.getQuestion());
 
-        return List.of(question);
+        return List.of(returnedQuestion);
     }
 }

--- a/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/QuestionsEntityResource.java
+++ b/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/QuestionsEntityResource.java
@@ -54,8 +54,6 @@ public class QuestionsEntityResource implements EntityResourceAction.Create<Ques
 
         log.info("Received question: {}", question);
 
-        Question returnedQuestion = new Question("questionId", question.getQuestion());
-
-        return List.of(returnedQuestion);
+        return List.of(question.withId("questionId"));
     }
 }

--- a/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/model/Question.java
+++ b/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/model/Question.java
@@ -28,6 +28,8 @@ package org.alfresco.hxi_connector.prediction_applier.rest.api.model;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
+import jakarta.validation.constraints.NotBlank;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -45,6 +47,7 @@ import lombok.experimental.Accessors;
 public class Question
 {
     private String _questionId;
+    @NotBlank
     private String question;
 
     public Question withId(String questionId)

--- a/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/model/Question.java
+++ b/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/model/Question.java
@@ -26,15 +26,24 @@
 
 package org.alfresco.hxi_connector.prediction_applier.rest.api.model;
 
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+@Accessors(prefix = {"_", ""})
 @ToString
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(NON_NULL)
+@SuppressWarnings("PMD.FieldNamingConventions")
 public class Question
 {
-    @Setter
-    private String questionId;
+    private String _questionId;
     private String question;
 }

--- a/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/model/Question.java
+++ b/prediction-applier-extension/src/main/java/org/alfresco/hxi_connector/prediction_applier/rest/api/model/Question.java
@@ -46,4 +46,10 @@ public class Question
 {
     private String _questionId;
     private String question;
+
+    public Question withId(String questionId)
+    {
+        this._questionId = questionId;
+        return this;
+    }
 }


### PR DESCRIPTION
This uses the annotations from `PredictionModel` to throw an error when a request tries to set the id field.