### PR TITLE
ACS-6826 test to apply prediction to updated node

### DIFF
--- a/e2e-test/src/test/java/org/alfresco/hxi_connector/e2e_test/UpdateNodeE2eTest.java
+++ b/e2e-test/src/test/java/org/alfresco/hxi_connector/e2e_test/UpdateNodeE2eTest.java
@@ -159,21 +159,21 @@ public class UpdateNodeE2eTest
         @Cleanup
         InputStream fileContent = new ByteArrayInputStream(DUMMY_CONTENT.getBytes());
         Node createdNode = repositoryNodesClient.createNodeWithContent(PARENT_ID, "dummy2.txt", fileContent, "text/plain");
-        Node updateNode = repositoryNodesClient.updateNodeWithContent(createdNode.id(), UPDATE_NODE_PROPERTIES);
+        Node updatedNode = repositoryNodesClient.updateNodeWithContent(createdNode.id(), UPDATE_NODE_PROPERTIES);
         RetryUtils.retryWithBackoff(() -> verify(moreThanOrExactly(1), postRequestedFor(urlEqualTo("/ingestion-events"))
-                .withRequestBody(containing(updateNode.id()))));
+                .withRequestBody(containing(updatedNode.id()))));
         WireMock.reset();
-        prepareHxInsightMockToReturnPredictionFor(updateNode.id());
+        prepareHxInsightMockToReturnPredictionFor(updatedNode.id());
 
         // when
         WireMock.setScenarioState(LIST_PREDICTIONS_SCENARIO, PREDICTIONS_AVAILABLE_STATE);
         WireMock.setScenarioState(LIST_PREDICTION_BATCHES_SCENARIO, PREDICTIONS_AVAILABLE_STATE);
 
         // then
-        assertThat(updateNode.aspects()).doesNotContain(PREDICTION_APPLIED_ASPECT);
-        assertThat(updateNode.properties()).doesNotContainKey(PROPERTY_TO_UPDATE);
+        assertThat(updatedNode.aspects()).doesNotContain(PREDICTION_APPLIED_ASPECT);
+        assertThat(updatedNode.properties()).doesNotContainKey(PROPERTY_TO_UPDATE);
         RetryUtils.retryWithBackoff(() -> {
-            Node actualNode = repositoryNodesClient.getNode(updateNode.id());
+            Node actualNode = repositoryNodesClient.getNode(updatedNode.id());
             assertThat(actualNode.aspects()).contains(PREDICTION_APPLIED_ASPECT);
             assertThat(actualNode.properties())
                     .containsKey(PROPERTY_TO_UPDATE)

--- a/e2e-test/src/test/java/org/alfresco/hxi_connector/e2e_test/UpdateNodeE2eTest.java
+++ b/e2e-test/src/test/java/org/alfresco/hxi_connector/e2e_test/UpdateNodeE2eTest.java
@@ -158,7 +158,7 @@ public class UpdateNodeE2eTest
         // given
         @Cleanup
         InputStream fileContent = new ByteArrayInputStream(DUMMY_CONTENT.getBytes());
-        Node createdNode = repositoryNodesClient.createNodeWithContent(PARENT_ID, "dummy.txt", fileContent, "text/plain");
+        Node createdNode = repositoryNodesClient.createNodeWithContent(PARENT_ID, "dummy2.txt", fileContent, "text/plain");
         Node updateNode = repositoryNodesClient.updateNodeWithContent(createdNode.id(), UPDATE_NODE_PROPERTIES);
         RetryUtils.retryWithBackoff(() -> verify(moreThanOrExactly(1), postRequestedFor(urlEqualTo("/ingestion-events"))
                 .withRequestBody(containing(updateNode.id()))));

--- a/e2e-test/src/test/java/org/alfresco/hxi_connector/e2e_test/UpdateNodeE2eTest.java
+++ b/e2e-test/src/test/java/org/alfresco/hxi_connector/e2e_test/UpdateNodeE2eTest.java
@@ -25,7 +25,17 @@
  */
 package org.alfresco.hxi_connector.e2e_test;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.givenThat;
+import static com.github.tomakehurst.wiremock.client.WireMock.moreThanOrExactly;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathTemplate;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/e2e-test/src/test/java/org/alfresco/hxi_connector/e2e_test/UpdateNodeE2eTest.java
+++ b/e2e-test/src/test/java/org/alfresco/hxi_connector/e2e_test/UpdateNodeE2eTest.java
@@ -94,7 +94,7 @@ public class UpdateNodeE2eTest
                 "properties": {
                     "cm:versionLabel": "1.1",
                     "cm:title": "User title"
-                    }
+                }
             }
             """;
 
@@ -160,7 +160,7 @@ public class UpdateNodeE2eTest
         InputStream fileContent = new ByteArrayInputStream(DUMMY_CONTENT.getBytes());
         Node createdNode = repositoryNodesClient.createNodeWithContent(PARENT_ID, "dummy2.txt", fileContent, "text/plain");
         Node updatedNode = repositoryNodesClient.updateNodeWithContent(createdNode.id(), UPDATE_NODE_PROPERTIES);
-        RetryUtils.retryWithBackoff(() -> verify(moreThanOrExactly(1), postRequestedFor(urlEqualTo("/ingestion-events"))
+        RetryUtils.retryWithBackoff(() -> verify(exactly(2), postRequestedFor(urlEqualTo("/ingestion-events"))
                 .withRequestBody(containing(updatedNode.id()))));
         WireMock.reset();
         prepareHxInsightMockToReturnPredictionFor(updatedNode.id());

--- a/e2e-test/src/test/java/org/alfresco/hxi_connector/e2e_test/util/client/RepositoryNodesClient.java
+++ b/e2e-test/src/test/java/org/alfresco/hxi_connector/e2e_test/util/client/RepositoryNodesClient.java
@@ -85,6 +85,7 @@ public class RepositoryNodesClient
                 .when().put(uri)
                 .then().extract().response()
                 .as(NodeEntry.class).node();
+    }
 
     public void deleteNode(String nodeId)
     {

--- a/e2e-test/src/test/java/org/alfresco/hxi_connector/e2e_test/util/client/RepositoryNodesClient.java
+++ b/e2e-test/src/test/java/org/alfresco/hxi_connector/e2e_test/util/client/RepositoryNodesClient.java
@@ -75,4 +75,15 @@ public class RepositoryNodesClient
                 .then().extract().response()
                 .as(NodeEntry.class).node();
     }
+
+    public Node updateNodeWithContent(String nodeId, String updateBody)
+    {
+        String uri = URL_PATTERN.formatted(baseUrl, nodeId);
+        return given().auth().preemptive().basic(username, password)
+                .contentType("application/json")
+                .body(updateBody)
+                .when().put(uri)
+                .then().extract().response()
+                .as(NodeEntry.class).node();
+    }
 }


### PR DESCRIPTION
[ACS-6826](https://hyland.atlassian.net/browse/ACS-6826)
Upload a new version of a document and check that HxI receives the metadata update then ACS receives prediction for the node.
Added test covers scenario:
1. node is created
2. prediction is generated for the node from step 1.
3. node from step 1. is updated together with field that has prediction from step 2.
4. prediction for updated node (in step 3.) is generated but updated node should not apply this prediction and keep updated user value

[ACS-6826]: https://hyland.atlassian.net/browse/ACS-6826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ