### PR TITLE
ACS-8262: Fixing docker images setup to handle Windows paths

### DIFF
--- a/common-test/src/main/java/org/alfresco/hxi_connector/common/test/docker/repository/AlfrescoRepositoryExtension.java
+++ b/common-test/src/main/java/org/alfresco/hxi_connector/common/test/docker/repository/AlfrescoRepositoryExtension.java
@@ -76,7 +76,7 @@ public class AlfrescoRepositoryExtension extends ImageFromDockerfile
                 .withDockerfileFromBuilder(builder -> builder
                         .from(dockerImageName.toString())
                         .user("root")
-                        .copy(jarFile.toString(), "/usr/local/tomcat/webapps/alfresco/WEB-INF/lib/")
+                        .copy(jarFile.toString().replace("\\", "/"), "/usr/local/tomcat/webapps/alfresco/WEB-INF/lib/")
                         .run("chown -R -h alfresco /usr/local/tomcat")
                         .user("alfresco")
                         .build());


### PR DESCRIPTION
This change makes it possible to run E2E tests in Windows OS.