### PR TITLE
ACS-6686 update version of digital workspace and control center

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,8 +101,8 @@
         <dist.transform.sfs.version>4.0.1</dist.transform.sfs.version>
         <dist.activemq.version>5.18.3</dist.activemq.version>
         <dist.activemq.docker.tag>${dist.activemq.version}-jre17-rockylinux8</dist.activemq.docker.tag>
-        <dist.digital.workspace.version>4.4.0-7099328816</dist.digital.workspace.version>
-        <dist.control.center.version>8.3.0</dist.control.center.version>
+        <dist.digital.workspace.version>4.5.0-9694926934</dist.digital.workspace.version>
+        <dist.control.center.version>8.5.0-9694926934</dist.control.center.version>
         <dist.nginx.version>3.4.2</dist.nginx.version>
         <dist.elasticsearch.version>7.17.15</dist.elasticsearch.version>
         <dist.search.enterprise.version>4.0.1</dist.search.enterprise.version>


### PR DESCRIPTION
[ACS-6686](https://hyland.atlassian.net/browse/ACS-6686)
Update version for ADW and ACC so we have the latest on hxi connector

[ACS-6686]: https://hyland.atlassian.net/browse/ACS-6686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ