### PR TITLE
Don't push images for feature branches. [skip tests]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,7 @@ jobs:
       - run_e2e_test
     if: >
       github.event_name == 'push' &&
+      (github.ref_name == 'master' || startsWith(github.ref_name, 'release/')) &&
       !(failure() || cancelled()) &&
       !contains(github.event.head_commit.message, '[skip build]')
     steps:


### PR DESCRIPTION
This job seems to take a reasonable amount of time, and to my knowledge none of us use the feature branch images from quay.