### PR TITLE
ACS-8149: Adding HxI API call to answers endpoint.

### DIFF
--- a/hxinsight-extension/src/main/java/org/alfresco/hxi_connector/hxi_extension/rest/api/QuestionAnswersRelation.java
+++ b/hxinsight-extension/src/main/java/org/alfresco/hxi_connector/hxi_extension/rest/api/QuestionAnswersRelation.java
@@ -29,6 +29,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.alfresco.hxi_connector.hxi_extension.rest.api.model.AnswerModel;
+import org.alfresco.hxi_connector.hxi_extension.service.HxInsightClient;
 import org.alfresco.rest.framework.WebApiDescription;
 import org.alfresco.rest.framework.resource.RelationshipResource;
 import org.alfresco.rest.framework.resource.actions.interfaces.RelationshipResourceAction;
@@ -40,11 +41,12 @@ import org.alfresco.rest.framework.resource.parameters.Parameters;
 @RelationshipResource(name = "answers", title = "Answers to questions about documents", entityResource = QuestionsEntityResource.class)
 public class QuestionAnswersRelation implements RelationshipResourceAction.Read<AnswerModel>
 {
+    private final HxInsightClient hxInsightClient;
 
     @WebApiDescription(title = "Get answers to a question")
     public CollectionWithPagingInfo<AnswerModel> readAll(String questionId, Parameters parameters)
     {
-        AnswerModel answerModel = new AnswerModel("Dummy answer");
-        return CollectionWithPagingInfo.asPagedCollection(answerModel);
+        hxInsightClient.getAnswer(questionId);
+        return CollectionWithPagingInfo.asPagedCollection(new AnswerModel("Dummy answer"));
     }
 }

--- a/hxinsight-extension/src/main/java/org/alfresco/hxi_connector/hxi_extension/service/HxInsightClient.java
+++ b/hxinsight-extension/src/main/java/org/alfresco/hxi_connector/hxi_extension/service/HxInsightClient.java
@@ -29,7 +29,7 @@ package org.alfresco.hxi_connector.hxi_extension.service;
 import static org.apache.http.HttpStatus.SC_ACCEPTED;
 import static org.apache.http.HttpStatus.SC_OK;
 
-import static org.alfresco.hxi_connector.common.util.EnsureUtils.ensureThat;
+import static org.alfresco.hxi_connector.common.util.ErrorUtils.throwExceptionOnUnexpectedStatusCode;
 
 import java.io.IOException;
 import java.net.URI;
@@ -45,7 +45,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.extensions.webscripts.WebScriptException;
 
 import org.alfresco.hxi_connector.common.exception.HxInsightConnectorRuntimeException;
 import org.alfresco.hxi_connector.hxi_extension.service.config.HxInsightClientConfig;
@@ -76,7 +75,7 @@ public class HxInsightClient
 
         HttpResponse<String> httpResponse = client.send(request, BodyHandlers.ofString());
 
-        propagateErrorIfNeeded(httpResponse.statusCode(), SC_OK);
+        throwExceptionOnUnexpectedStatusCode(httpResponse.statusCode(), SC_OK);
 
         return objectMapper.readValue(httpResponse.body(), new TypeReference<>() {});
     }
@@ -97,7 +96,7 @@ public class HxInsightClient
 
             HttpResponse<String> httpResponse = client.send(request, BodyHandlers.ofString());
 
-            propagateErrorIfNeeded(httpResponse.statusCode(), SC_ACCEPTED);
+            throwExceptionOnUnexpectedStatusCode(httpResponse.statusCode(), SC_ACCEPTED);
 
             return objectMapper.readValue(httpResponse.body(), QuestionResponse.class)
                     .questionId();
@@ -121,7 +120,7 @@ public class HxInsightClient
             HttpResponse<String> httpResponse = client.send(request, BodyHandlers.ofString());
             log.atDebug().log("Question with id {} received a following answer {}", questionId, httpResponse.body());
 
-            propagateErrorIfNeeded(httpResponse.statusCode(), SC_OK);
+            throwExceptionOnUnexpectedStatusCode(httpResponse.statusCode(), SC_OK);
 
             return objectMapper.readValue(httpResponse.body(), AnswerResponse.class);
         }
@@ -129,10 +128,5 @@ public class HxInsightClient
         {
             throw new HxInsightConnectorRuntimeException("Failed to get answer to question with id %s".formatted(questionId), e);
         }
-    }
-
-    private static void propagateErrorIfNeeded(int responseStatusCode, int expectedStatusCode)
-    {
-        ensureThat(expectedStatusCode == responseStatusCode, () -> new WebScriptException(responseStatusCode, "Hx Insight API returned an error"));
     }
 }

--- a/hxinsight-extension/src/main/java/org/alfresco/hxi_connector/hxi_extension/service/HxInsightClient.java
+++ b/hxinsight-extension/src/main/java/org/alfresco/hxi_connector/hxi_extension/service/HxInsightClient.java
@@ -49,6 +49,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.alfresco.hxi_connector.common.exception.HxInsightConnectorRuntimeException;
 import org.alfresco.hxi_connector.hxi_extension.service.config.HxInsightClientConfig;
 import org.alfresco.hxi_connector.hxi_extension.service.model.Agent;
+import org.alfresco.hxi_connector.hxi_extension.service.model.AnswerResponse;
 import org.alfresco.hxi_connector.hxi_extension.service.model.Question;
 import org.alfresco.hxi_connector.hxi_extension.service.model.QuestionResponse;
 import org.alfresco.hxi_connector.hxi_extension.service.util.AuthService;
@@ -103,6 +104,29 @@ public class HxInsightClient
         catch (IOException | InterruptedException e)
         {
             throw new HxInsightConnectorRuntimeException("Failed to ask question", e);
+        }
+    }
+
+    public AnswerResponse getAnswer(String questionId)
+    {
+        try
+        {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(config.getAnswerUrl().formatted(questionId)))
+                    .headers(authService.getAuthHeaders())
+                    .GET()
+                    .build();
+
+            HttpResponse<String> httpResponse = client.send(request, BodyHandlers.ofString());
+            log.atDebug().log("Question with id {} received a following answer {}", questionId, httpResponse.body());
+
+            throwExceptionOnUnexpectedStatusCode(httpResponse.statusCode(), SC_OK);
+
+            return objectMapper.readValue(httpResponse.body(), AnswerResponse.class);
+        }
+        catch (IOException | InterruptedException e)
+        {
+            throw new HxInsightConnectorRuntimeException("Failed to get answer to question with id %s".formatted(questionId), e);
         }
     }
 }

--- a/hxinsight-extension/src/main/java/org/alfresco/hxi_connector/hxi_extension/service/model/AnswerResponse.java
+++ b/hxinsight-extension/src/main/java/org/alfresco/hxi_connector/hxi_extension/service/model/AnswerResponse.java
@@ -1,4 +1,4 @@
-/*
+/*-
  * #%L
  * Alfresco HX Insight Connector
  * %%
@@ -23,24 +23,32 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%
  */
+package org.alfresco.hxi_connector.hxi_extension.service.model;
 
-package org.alfresco.hxi_connector.hxi_extension.service.config;
+import java.util.List;
 
-import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-import lombok.Getter;
-
-@Getter
-public final class HxInsightClientConfig
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AnswerResponse
 {
-    private final String agentUrl;
-    private final String questionUrl;
-    private final String answerUrl;
+    private String questionId;
+    private String question;
+    private String agentId;
+    private String agentVersion;
+    private String answer;
+    private List<Reference> references;
 
-    public HxInsightClientConfig(@NotBlank String baseUrl)
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Reference
     {
-        this.agentUrl = baseUrl + "/v1/agents";
-        this.questionUrl = baseUrl + "/v1/questions";
-        this.answerUrl = questionUrl + "/%s/answer";
+        private String referenceId;
+        private String textReference;
     }
 }

--- a/hxinsight-extension/src/test/java/org/alfresco/hxi_connector/hxi_extension/rest/api/QuestionAnswersRelationTest.java
+++ b/hxinsight-extension/src/test/java/org/alfresco/hxi_connector/hxi_extension/rest/api/QuestionAnswersRelationTest.java
@@ -1,4 +1,4 @@
-/*
+/*-
  * #%L
  * Alfresco HX Insight Connector
  * %%
@@ -23,24 +23,38 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%
  */
+package org.alfresco.hxi_connector.hxi_extension.rest.api;
 
-package org.alfresco.hxi_connector.hxi_extension.service.config;
+import static org.mockito.BDDMockito.then;
 
-import jakarta.validation.constraints.NotBlank;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import lombok.Getter;
+import org.alfresco.hxi_connector.hxi_extension.service.HxInsightClient;
 
-@Getter
-public final class HxInsightClientConfig
+@ExtendWith(MockitoExtension.class)
+class QuestionAnswersRelationTest
 {
-    private final String agentUrl;
-    private final String questionUrl;
-    private final String answerUrl;
 
-    public HxInsightClientConfig(@NotBlank String baseUrl)
+    @Mock
+    private HxInsightClient mockHxInsightClient;
+
+    @InjectMocks
+    private QuestionAnswersRelation objectUnderTest;
+
+    @Test
+    void shouldCallHxInsightClientGetAnswer()
     {
-        this.agentUrl = baseUrl + "/v1/agents";
-        this.questionUrl = baseUrl + "/v1/questions";
-        this.answerUrl = questionUrl + "/%s/answer";
+        // given
+        String questionId = "questionId";
+
+        // when
+        objectUnderTest.readAll(questionId, null);
+
+        // then
+        then(mockHxInsightClient).should().getAnswer(questionId);
     }
 }

--- a/hxinsight-extension/src/test/java/org/alfresco/hxi_connector/hxi_extension/rest/api/QuestionAnswersRelationTest.java
+++ b/hxinsight-extension/src/test/java/org/alfresco/hxi_connector/hxi_extension/rest/api/QuestionAnswersRelationTest.java
@@ -36,6 +36,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.alfresco.hxi_connector.hxi_extension.service.HxInsightClient;
 
 @ExtendWith(MockitoExtension.class)
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 class QuestionAnswersRelationTest
 {
 

--- a/hxinsight-extension/src/test/java/org/alfresco/hxi_connector/hxi_extension/service/HxInsightClientTest.java
+++ b/hxinsight-extension/src/test/java/org/alfresco/hxi_connector/hxi_extension/service/HxInsightClientTest.java
@@ -45,8 +45,8 @@ import lombok.SneakyThrows;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.extensions.webscripts.WebScriptException;
 
+import org.alfresco.hxi_connector.common.exception.EndpointClientErrorException;
 import org.alfresco.hxi_connector.hxi_extension.service.config.HxInsightClientConfig;
 import org.alfresco.hxi_connector.hxi_extension.service.model.AnswerResponse;
 import org.alfresco.hxi_connector.hxi_extension.service.model.Question;
@@ -115,7 +115,7 @@ class HxInsightClientTest
         given(httpClient.send(any(), any())).willReturn(response);
 
         // when
-        assertThrows(WebScriptException.class, () -> hxInsightClient.askQuestion(
+        assertThrows(EndpointClientErrorException.class, () -> hxInsightClient.askQuestion(
                 new Question("Who won last year's Super Bowl?", "")));
     }
 
@@ -154,7 +154,7 @@ class HxInsightClientTest
         given(config.getAnswerUrl()).willReturn("http://hxinsight/question/%s/answer");
 
         // when + then
-        assertThrows(WebScriptException.class, () -> hxInsightClient.getAnswer(questionId));
+        assertThrows(EndpointClientErrorException.class, () -> hxInsightClient.getAnswer(questionId));
     }
 
 }

--- a/hxinsight-extension/src/test/java/org/alfresco/hxi_connector/hxi_extension/service/HxInsightClientTest.java
+++ b/hxinsight-extension/src/test/java/org/alfresco/hxi_connector/hxi_extension/service/HxInsightClientTest.java
@@ -45,8 +45,8 @@ import lombok.SneakyThrows;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.extensions.webscripts.WebScriptException;
 
-import org.alfresco.hxi_connector.common.exception.EndpointClientErrorException;
 import org.alfresco.hxi_connector.hxi_extension.service.config.HxInsightClientConfig;
 import org.alfresco.hxi_connector.hxi_extension.service.model.AnswerResponse;
 import org.alfresco.hxi_connector.hxi_extension.service.model.Question;
@@ -115,7 +115,7 @@ class HxInsightClientTest
         given(httpClient.send(any(), any())).willReturn(response);
 
         // when
-        assertThrows(EndpointClientErrorException.class, () -> hxInsightClient.askQuestion(
+        assertThrows(WebScriptException.class, () -> hxInsightClient.askQuestion(
                 new Question("Who won last year's Super Bowl?", "")));
     }
 
@@ -154,7 +154,7 @@ class HxInsightClientTest
         given(config.getAnswerUrl()).willReturn("http://hxinsight/question/%s/answer");
 
         // when + then
-        assertThrows(EndpointClientErrorException.class, () -> hxInsightClient.getAnswer(questionId));
+        assertThrows(WebScriptException.class, () -> hxInsightClient.getAnswer(questionId));
     }
 
 }


### PR DESCRIPTION
As per https://hyland.atlassian.net/browse/ACS-8150 - the result is not yet returned by the REST API but only logged (at DEBUG level).