### PR TITLE
Add all jars and license files to distribution zip

### DIFF
--- a/distribution/src/main/assemble/distribution-zip-assembly.xml
+++ b/distribution/src/main/assemble/distribution-zip-assembly.xml
@@ -12,6 +12,9 @@
             <directory>${project.basedir}/target/dependency</directory>
             <includes>
                 <include>alfresco-hxinsight-connector-live-ingester-${project.version}-app.jar</include>
+                <include>alfresco-hxinsight-connector-bulk-ingester-${project.version}-app.jar</include>
+                <include>alfresco-hxinsight-connector-prediction-applier-${project.version}-app.jar</include>
+                <include>alfresco-hxinsight-connector-hxinsight-extension-${project.version}.jar</include>
             </includes>
             <outputDirectory>./</outputDirectory>
         </fileSet>
@@ -33,12 +36,39 @@
             <directory>${project.parent.basedir}/live-ingester/target/generated-resources/licenses</directory>
             <outputDirectory>third-party-licenses-live-ingester</outputDirectory>
         </fileSet>
+        <fileSet>
+            <directory>${project.parent.basedir}/bulk-ingester/target/generated-resources/licenses</directory>
+            <outputDirectory>third-party-licenses-bulk-ingester</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>${project.parent.basedir}/prediction-applier/target/generated-resources/licenses</directory>
+            <outputDirectory>third-party-licenses-prediction-applier</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>${project.parent.basedir}/hxinsight-extension/target/generated-resources/licenses</directory>
+            <outputDirectory>third-party-licenses-hxinsight-extension</outputDirectory>
+        </fileSet>
     </fileSets>
     <files>
         <file>
             <source>${project.parent.basedir}/live-ingester/target/generated-sources/license/THIRD-PARTY.txt</source>
             <outputDirectory>.</outputDirectory>
             <destName>third-party-live-ingester.txt</destName>
+        </file>
+        <file>
+            <source>${project.parent.basedir}/bulk-ingester/target/generated-sources/license/THIRD-PARTY.txt</source>
+            <outputDirectory>.</outputDirectory>
+            <destName>third-party-bulk-ingester.txt</destName>
+        </file>
+        <file>
+            <source>${project.parent.basedir}/prediction-applier/target/generated-sources/license/THIRD-PARTY.txt</source>
+            <outputDirectory>.</outputDirectory>
+            <destName>third-party-prediction-applier.txt</destName>
+        </file>
+        <file>
+            <source>${project.parent.basedir}/hxinsight-extension/target/generated-sources/license/THIRD-PARTY.txt</source>
+            <outputDirectory>.</outputDirectory>
+            <destName>third-party-hxinsight-extension.txt</destName>
         </file>
     </files>
 </assembly>


### PR DESCRIPTION
While working on implementing the SAST scan on PR, I noticed that the distribution zip did not contain all that I was expecting. In particular, it only contained the jar and license files for the `live-ingester` module.

I talked with @tpage-alfresco and he confirmed that this was not the expected result, so I went ahead and added all other jars and license files to the distribution zip. This will also be useful for the SAST scan on PR feature which I'll continue working on a separate branch.

### Before

![image](https://github.com/Alfresco/hxinsight-connector/assets/24280982/14979609-6fd7-4bbc-81e3-35d2ce004de4)

### After

![image](https://github.com/Alfresco/hxinsight-connector/assets/24280982/11e9ad5e-acba-47e6-b816-92f878c0dcf9)
