### PR TITLE
ACS-8363: User-Agent header in presigned URL call

### DIFF
--- a/e2e-test/src/test/java/org/alfresco/hxi_connector/e2e_test/UpdateNodeE2eTest.java
+++ b/e2e-test/src/test/java/org/alfresco/hxi_connector/e2e_test/UpdateNodeE2eTest.java
@@ -31,6 +31,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.containing;
 import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.givenThat;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
 import static com.github.tomakehurst.wiremock.client.WireMock.moreThanOrExactly;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
@@ -39,6 +40,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import static org.alfresco.hxi_connector.common.constant.HttpHeaders.USER_AGENT;
+import static org.alfresco.hxi_connector.common.test.docker.util.DockerContainers.getAppInfoRegex;
 import static org.alfresco.hxi_connector.common.test.docker.util.DockerContainers.getMinimalRepoJavaOpts;
 import static org.alfresco.hxi_connector.e2e_test.util.client.RepositoryClient.ADMIN_USER;
 
@@ -159,14 +162,15 @@ public class UpdateNodeE2eTest
 
     @Test
     @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-    void testApplyPredictionToUpdatedNode() throws IOException
+    void testApplyPredictionToUpdatedNode() throws IOException, InterruptedException
     {
         // given
         @Cleanup
         InputStream fileContent = new ByteArrayInputStream(DUMMY_CONTENT.getBytes());
         Node createdNode = repositoryNodesClient.createNodeWithContent(PARENT_ID, "dummy2.txt", fileContent, "text/plain");
         RetryUtils.retryWithBackoff(() -> verify(moreThanOrExactly(1), postRequestedFor(urlEqualTo("/ingestion-events"))
-                .withRequestBody(containing(createdNode.id()))));
+                .withRequestBody(containing(createdNode.id()))
+                .withHeader(USER_AGENT, matching(getAppInfoRegex()))));
         WireMock.reset();
         prepareHxInsightMockToReturnPredictionFor(createdNode.id(), PREDICTED_VALUE);
 
@@ -181,7 +185,8 @@ public class UpdateNodeE2eTest
         // when
         Node updatedNode = repositoryNodesClient.updateNodeWithContent(createdNode.id(), UPDATE_NODE_PROPERTIES);
         RetryUtils.retryWithBackoff(() -> verify(exactly(1), postRequestedFor(urlEqualTo("/ingestion-events"))
-                .withRequestBody(containing(updatedNode.id()))));
+                .withRequestBody(containing(updatedNode.id()))
+                .withHeader(USER_AGENT, matching(getAppInfoRegex()))));
         WireMock.reset();
         prepareHxInsightMockToReturnPredictionFor(updatedNode.id(), PREDICTED_VALUE_2);
 

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/hx_insight/storage/connector/PreSignedUrlRequesterIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/hx_insight/storage/connector/PreSignedUrlRequesterIntegrationTest.java
@@ -30,11 +30,13 @@ import static com.github.tomakehurst.wiremock.client.WireMock.absent;
 import static com.github.tomakehurst.wiremock.client.WireMock.badRequest;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.givenThat;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.serverError;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.apache.hc.core5.http.HttpHeaders.AUTHORIZATION;
+import static org.apache.http.HttpHeaders.USER_AGENT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.BDDMockito.then;
@@ -42,6 +44,7 @@ import static org.mockito.Mockito.times;
 
 import static org.alfresco.hxi_connector.common.adapters.auth.AuthService.HXI_AUTH_PROVIDER;
 import static org.alfresco.hxi_connector.common.adapters.auth.util.AuthUtils.AUTH_HEADER;
+import static org.alfresco.hxi_connector.common.test.docker.util.DockerContainers.getAppInfoRegex;
 import static org.alfresco.hxi_connector.live_ingester.adapters.messaging.hx_insight.storage.connector.PreSignedUrlRequester.STORAGE_LOCATION_PROPERTY;
 
 import java.net.MalformedURLException;
@@ -61,6 +64,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.retry.annotation.EnableRetry;
@@ -86,12 +90,15 @@ import org.alfresco.hxi_connector.common.test.docker.util.DockerContainers;
 import org.alfresco.hxi_connector.live_ingester.adapters.auth.LiveIngesterAuthClient;
 import org.alfresco.hxi_connector.live_ingester.adapters.config.IntegrationProperties;
 import org.alfresco.hxi_connector.live_ingester.adapters.messaging.hx_insight.storage.connector.model.PreSignedUrlResponse;
+import org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.ApplicationInfoProvider;
+import org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.api.DiscoveryApiClient;
 
 @SpringBootTest(classes = {
         IntegrationProperties.class,
         PreSignedUrlRequester.class,
         LiveIngesterAuthClient.class,
-        PreSignedUrlRequesterIntegrationTest.PreSignedUrlRequesterIntegrationTestConfig.class},
+        PreSignedUrlRequesterIntegrationTest.PreSignedUrlRequesterIntegrationTestConfig.class,
+        ApplicationInfoProvider.class},
         properties = "logging.level.org.alfresco=DEBUG")
 @EnableAutoConfiguration
 @EnableRetry
@@ -99,11 +106,9 @@ import org.alfresco.hxi_connector.live_ingester.adapters.messaging.hx_insight.st
 @Testcontainers
 class PreSignedUrlRequesterIntegrationTest
 {
-    private static final String NODE_ID = "some-node-ref";
     private static final String PRE_SIGNED_URL_PATH = "/presigned-urls";
     private static final String CONTENT_ID = "CONTENT ID";
     private static final String CAMEL_ENDPOINT_PATTERN = "%s%s?httpMethod=POST&throwExceptionOnFailure=false";
-    private static final String FILE_CONTENT_TYPE = "plain/text";
     private static final String HX_INSIGHT_RESPONSE_BODY_PATTERN = "[{\"%s\": \"%s\", \"id\": \"CONTENT ID\"}]";
     private static final int HX_INSIGHT_RESPONSE_CODE = 200;
     private static final int RETRY_ATTEMPTS = 3;
@@ -139,6 +144,7 @@ class PreSignedUrlRequesterIntegrationTest
         // then
         WireMock.verify(postRequestedFor(urlPathEqualTo(PRE_SIGNED_URL_PATH))
                 .withHeader(AUTHORIZATION, equalTo(AUTH_HEADER))
+                .withHeader(USER_AGENT, matching(getAppInfoRegex()))
                 .withRequestBody(absent()));
         PreSignedUrlResponse expected = new PreSignedUrlResponse(new URL(preSignedUrl), CONTENT_ID);
         assertThat(preSignedUrlResponse).isEqualTo(expected);
@@ -297,5 +303,8 @@ class PreSignedUrlRequesterIntegrationTest
         {
             return new AuthService(authorizationProperties(), defaultAccessTokenProvider());
         }
+
+        @MockBean
+        public DiscoveryApiClient discoveryApi;
     }
 }

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/hx_insight/storage/connector/PreSignedUrlRequesterIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/hx_insight/storage/connector/PreSignedUrlRequesterIntegrationTest.java
@@ -274,6 +274,9 @@ class PreSignedUrlRequesterIntegrationTest
     public static class PreSignedUrlRequesterIntegrationTestConfig
     {
 
+        @MockBean
+        public DiscoveryApiClient discoveryApi;
+
         @Bean
         public AuthProperties authorizationProperties()
         {
@@ -303,8 +306,5 @@ class PreSignedUrlRequesterIntegrationTest
         {
             return new AuthService(authorizationProperties(), defaultAccessTokenProvider());
         }
-
-        @MockBean
-        public DiscoveryApiClient discoveryApi;
     }
 }

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/hx_insight/storage/connector/PreSignedUrlRequester.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/hx_insight/storage/connector/PreSignedUrlRequester.java
@@ -28,6 +28,7 @@ package org.alfresco.hxi_connector.live_ingester.adapters.messaging.hx_insight.s
 import static org.apache.camel.Exchange.HTTP_RESPONSE_CODE;
 
 import static org.alfresco.hxi_connector.common.util.ErrorUtils.UNEXPECTED_STATUS_CODE_MESSAGE;
+import static org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.ApplicationInfoProvider.USER_AGENT_DATA;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -51,6 +52,7 @@ import org.alfresco.hxi_connector.common.exception.EndpointServerErrorException;
 import org.alfresco.hxi_connector.common.util.ErrorUtils;
 import org.alfresco.hxi_connector.live_ingester.adapters.config.IntegrationProperties;
 import org.alfresco.hxi_connector.live_ingester.adapters.messaging.hx_insight.storage.connector.model.PreSignedUrlResponse;
+import org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.ApplicationInfoProvider;
 import org.alfresco.hxi_connector.live_ingester.domain.exception.LiveIngesterRuntimeException;
 
 @Component
@@ -67,6 +69,7 @@ public class PreSignedUrlRequester extends RouteBuilder implements StorageLocati
     private final CamelContext camelContext;
     private final IntegrationProperties integrationProperties;
     private final AuthService authService;
+    private final ApplicationInfoProvider applicationInfoProvider;
 
     @Override
     public void configure()
@@ -79,8 +82,9 @@ public class PreSignedUrlRequester extends RouteBuilder implements StorageLocati
 
         from(LOCAL_ENDPOINT)
             .id(ROUTE_ID)
+            .setProperty(USER_AGENT_DATA, applicationInfoProvider::getUserAgentData)
             .process(authService::setHxIAuthorizationHeaders)
-            .to(integrationProperties.hylandExperience().storage().location().endpoint())
+            .toD(integrationProperties.hylandExperience().storage().location().endpoint() + ApplicationInfoProvider.USER_AGENT_PARAM)
             .choice()
             .when(header(HTTP_RESPONSE_CODE).isEqualTo(String.valueOf(EXPECTED_STATUS_CODE)))
                 .unmarshal()

--- a/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/hx_insight/storage/connector/PreSignedUrlRequesterTest.java
+++ b/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/hx_insight/storage/connector/PreSignedUrlRequesterTest.java
@@ -29,6 +29,7 @@ import static org.apache.camel.Exchange.HTTP_RESPONSE_CODE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.reset;
 import static org.mockito.MockitoAnnotations.openMocks;
@@ -60,6 +61,7 @@ import org.alfresco.hxi_connector.common.exception.EndpointServerErrorException;
 import org.alfresco.hxi_connector.live_ingester.adapters.config.IntegrationProperties;
 import org.alfresco.hxi_connector.live_ingester.adapters.config.properties.Storage;
 import org.alfresco.hxi_connector.live_ingester.adapters.messaging.hx_insight.storage.connector.model.PreSignedUrlResponse;
+import org.alfresco.hxi_connector.live_ingester.adapters.messaging.repository.ApplicationInfoProvider;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class PreSignedUrlRequesterTest
@@ -72,6 +74,8 @@ class PreSignedUrlRequesterTest
 
     @Mock
     private AuthService mockAuthService;
+    @Mock
+    private ApplicationInfoProvider mockApplicationInfoProvider;
     CamelContext camelContext;
     MockEndpoint mockEndpoint;
 
@@ -84,11 +88,12 @@ class PreSignedUrlRequesterTest
         openMocks(this);
         camelContext = new DefaultCamelContext();
         IntegrationProperties integrationProperties = integrationPropertiesOf(MOCK_ENDPOINT);
-        preSignedUrlRequester = new PreSignedUrlRequester(camelContext, integrationProperties, mockAuthService);
+        given(mockApplicationInfoProvider.getUserAgentData()).willReturn("");
+        preSignedUrlRequester = new PreSignedUrlRequester(camelContext, integrationProperties, mockAuthService, mockApplicationInfoProvider);
         camelContext.addRoutes(preSignedUrlRequester);
         camelContext.start();
 
-        mockEndpoint = camelContext.getEndpoint(MOCK_ENDPOINT, MockEndpoint.class);
+        mockEndpoint = camelContext.getEndpoint(MOCK_ENDPOINT + "&userAgent=", MockEndpoint.class);
     }
 
     @AfterEach


### PR DESCRIPTION
As discussed on the daily meeting - adding user-agent header for presigned URL call.