### PR TITLE
ACS-8477 submit question changes

### DIFF
--- a/distribution/src/main/resources/docker-compose/wiremock/hxinsight/mappings/post-question.json
+++ b/distribution/src/main/resources/docker-compose/wiremock/hxinsight/mappings/post-question.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "POST",
-    "urlPath": "/questions"
+    "urlPath": "/submit-question"
   },
   "response": {
     "status": 202,

--- a/e2e-test/src/test/resources/wiremock/hxinsight/mappings/post-question.json
+++ b/e2e-test/src/test/resources/wiremock/hxinsight/mappings/post-question.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "POST",
-    "urlPath": "/questions"
+    "urlPath": "/submit-question"
   },
   "response": {
     "status": 202,

--- a/hxinsight-extension/src/main/java/org/alfresco/hxi_connector/hxi_extension/rest/api/QuestionsEntityResource.java
+++ b/hxinsight-extension/src/main/java/org/alfresco/hxi_connector/hxi_extension/rest/api/QuestionsEntityResource.java
@@ -86,7 +86,7 @@ public class QuestionsEntityResource implements EntityResourceAction.Create<Ques
 
         log.info("Received question: {}", question);
 
-        ensureThat(question.getRestrictionQuery().getNodesIds().size() <= questionConfig.getMaxContextSizeForQuestion(),
+        ensureThat(questionModel.getRestrictionQuery().getNodesIds().size() <= questionConfig.getMaxContextSizeForQuestion(),
                 () -> new WebScriptException(Status.STATUS_BAD_REQUEST, String.format("You can only ask about up to %d nodes at a time.", questionConfig.getMaxContextSizeForQuestion())));
         ensureThat(questionPermissionService.hasPermissionToAskAboutDocuments(question),
                 () -> new WebScriptException(Status.STATUS_FORBIDDEN, "You don't have permission to ask about some nodes"));

--- a/hxinsight-extension/src/main/java/org/alfresco/hxi_connector/hxi_extension/rest/api/model/QuestionModel.java
+++ b/hxinsight-extension/src/main/java/org/alfresco/hxi_connector/hxi_extension/rest/api/model/QuestionModel.java
@@ -61,6 +61,6 @@ public class QuestionModel
 
     public Question toQuestion()
     {
-        return new Question(question, agentId, restrictionQuery);
+        return new Question(question, agentId, restrictionQuery.toContextObjects());
     }
 }

--- a/hxinsight-extension/src/main/java/org/alfresco/hxi_connector/hxi_extension/service/QuestionPermissionService.java
+++ b/hxinsight-extension/src/main/java/org/alfresco/hxi_connector/hxi_extension/service/QuestionPermissionService.java
@@ -31,6 +31,7 @@ import static org.alfresco.service.cmr.security.PermissionService.READ;
 
 import lombok.RequiredArgsConstructor;
 
+import org.alfresco.hxi_connector.hxi_extension.service.model.ObjectReference;
 import org.alfresco.hxi_connector.hxi_extension.service.model.Question;
 import org.alfresco.rest.api.Nodes;
 import org.alfresco.service.cmr.security.AccessStatus;
@@ -44,9 +45,9 @@ public class QuestionPermissionService
 
     public boolean hasPermissionToAskAboutDocuments(Question question)
     {
-        return question.getRestrictionQuery()
-                .getNodesIds()
+        return question.getContextObjects()
                 .stream()
+                .map(ObjectReference::getObjectId)
                 .map(nodeId -> validateOrLookupNode(nodes, nodeId))
                 .map(nodeRef -> permissionService.hasPermission(nodeRef, READ))
                 .allMatch(AccessStatus.ALLOWED::equals);

--- a/hxinsight-extension/src/main/java/org/alfresco/hxi_connector/hxi_extension/service/config/HxInsightClientConfig.java
+++ b/hxinsight-extension/src/main/java/org/alfresco/hxi_connector/hxi_extension/service/config/HxInsightClientConfig.java
@@ -41,8 +41,8 @@ public final class HxInsightClientConfig
     public HxInsightClientConfig(@NotBlank String baseUrl)
     {
         this.agentUrl = baseUrl + "/agents";
-        this.questionUrl = baseUrl + "/questions";
-        this.answerUrl = questionUrl + "/%s/answer";
+        this.questionUrl = baseUrl + "/submit-question";
+        this.answerUrl = baseUrl + "/questions/%s/answer";
         this.feedbackUrl = answerUrl + "/feedback";
     }
 }

--- a/hxinsight-extension/src/main/java/org/alfresco/hxi_connector/hxi_extension/service/model/ObjectReference.java
+++ b/hxinsight-extension/src/main/java/org/alfresco/hxi_connector/hxi_extension/service/model/ObjectReference.java
@@ -23,21 +23,14 @@
  * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
  * #L%
  */
-
 package org.alfresco.hxi_connector.hxi_extension.service.model;
 
-import static lombok.AccessLevel.NONE;
-
-import java.util.Set;
-
+import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.Setter;
 
 @Data
-@Setter(NONE)
-public class Question
+@AllArgsConstructor
+public class ObjectReference
 {
-    private final String question;
-    private final String agentId;
-    private final Set<ObjectReference> contextObjects;
+    public String objectId;
 }

--- a/hxinsight-extension/src/main/java/org/alfresco/hxi_connector/hxi_extension/service/model/RestrictionQuery.java
+++ b/hxinsight-extension/src/main/java/org/alfresco/hxi_connector/hxi_extension/service/model/RestrictionQuery.java
@@ -26,6 +26,8 @@
 
 package org.alfresco.hxi_connector.hxi_extension.service.model;
 
+import static java.util.stream.Collectors.toSet;
+
 import java.util.Set;
 
 import lombok.AllArgsConstructor;
@@ -38,4 +40,9 @@ import lombok.NoArgsConstructor;
 public class RestrictionQuery
 {
     private Set<String> nodesIds;
+
+    public Set<ObjectReference> toContextObjects()
+    {
+        return nodesIds.stream().map(ObjectReference::new).collect(toSet());
+    }
 }

--- a/hxinsight-extension/src/test/java/org/alfresco/hxi_connector/hxi_extension/service/HxInsightClientTest.java
+++ b/hxinsight-extension/src/test/java/org/alfresco/hxi_connector/hxi_extension/service/HxInsightClientTest.java
@@ -62,15 +62,15 @@ import org.alfresco.hxi_connector.hxi_extension.service.config.HxInsightClientCo
 import org.alfresco.hxi_connector.hxi_extension.service.model.Agent;
 import org.alfresco.hxi_connector.hxi_extension.service.model.AnswerResponse;
 import org.alfresco.hxi_connector.hxi_extension.service.model.Feedback;
+import org.alfresco.hxi_connector.hxi_extension.service.model.ObjectReference;
 import org.alfresco.hxi_connector.hxi_extension.service.model.Question;
-import org.alfresco.hxi_connector.hxi_extension.service.model.RestrictionQuery;
 import org.alfresco.hxi_connector.hxi_extension.service.util.AuthService;
 
 @SuppressWarnings("PMD.FieldNamingConventions")
 class HxInsightClientTest
 {
     private static final String AGENT_ID = "agent-id";
-    private static final RestrictionQuery restrictionQuery = new RestrictionQuery(Set.of("dummy-node-id"));
+    private static final Set<ObjectReference> OBJECT_REFERENCES = Set.of(new ObjectReference("dummy-node-id"));
 
     private final HxInsightClientConfig config = new HxInsightClientConfig("http://hxinsight");
     private final AuthService authService = mock(AuthService.class);
@@ -111,7 +111,7 @@ class HxInsightClientTest
 
         // when
         String actualQuestionId = hxInsightClient.askQuestion(
-                new Question("Who won last year's Super Bowl?", AGENT_ID, restrictionQuery));
+                new Question("Who won last year's Super Bowl?", AGENT_ID, OBJECT_REFERENCES));
 
         // then
         assertEquals(expectedQuestionId, actualQuestionId);
@@ -131,7 +131,7 @@ class HxInsightClientTest
 
         // when, then
         WebScriptException exception = assertThrows(WebScriptException.class, () -> hxInsightClient.askQuestion(
-                new Question("Who won last year's Super Bowl?", AGENT_ID, restrictionQuery)));
+                new Question("Who won last year's Super Bowl?", AGENT_ID, OBJECT_REFERENCES)));
         assertEquals(expectedStatusCode, exception.getStatus());
     }
 
@@ -144,7 +144,7 @@ class HxInsightClientTest
 
         // when, then
         WebScriptException exception = assertThrows(WebScriptException.class, () -> hxInsightClient.askQuestion(
-                new Question("Who won last year's Super Bowl?", AGENT_ID, restrictionQuery)));
+                new Question("Who won last year's Super Bowl?", AGENT_ID, OBJECT_REFERENCES)));
         assertEquals(SC_SERVICE_UNAVAILABLE, exception.getStatus());
     }
 
@@ -339,7 +339,7 @@ class HxInsightClientTest
         given(httpClient.send(ArgumentMatchers.argThat(questionMatcher), any())).willReturn(questionResponse);
 
         // when
-        Question question = new Question("Create a sonnet about the Super Bowl", AGENT_ID, restrictionQuery);
+        Question question = new Question("Create a sonnet about the Super Bowl", AGENT_ID, OBJECT_REFERENCES);
         String newQuestionId = hxInsightClient.retryQuestion(questionId, "The fourth line was not quite in iambic pentameter", question);
 
         // then

--- a/hxinsight-extension/src/test/java/org/alfresco/hxi_connector/hxi_extension/service/HxInsightClientTest.java
+++ b/hxinsight-extension/src/test/java/org/alfresco/hxi_connector/hxi_extension/service/HxInsightClientTest.java
@@ -335,7 +335,7 @@ class HxInsightClientTest
                     "questionId": "dummy-id-5678"
                 }
                 """);
-        ArgumentMatcher<? extends HttpRequest> questionMatcher = request -> request != null && request.uri().toString().equals("http://hxinsight/questions");
+        ArgumentMatcher<? extends HttpRequest> questionMatcher = request -> request != null && request.uri().toString().equals("http://hxinsight/submit-question");
         given(httpClient.send(ArgumentMatchers.argThat(questionMatcher), any())).willReturn(questionResponse);
 
         // when


### PR DESCRIPTION
Update to match the `submit-question` API description: http://hxai-data-platform-dev-swagger-ui.s3-website-us-east-1.amazonaws.com/?urls.primaryName=Insight%20Discovery%20API%20Draft#/Discovery-Agent-API/post_question

The main changes are to call `POST /submit-question` rather than `POST /questions` and to pass the noderefs in a set of `ObjectReference` objects.