### PR TITLE
ACS-8482 Add missing @Validated annotation

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -20,6 +20,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/common/src/main/java/org/alfresco/hxi_connector/common/config/properties/Application.java
+++ b/common/src/main/java/org/alfresco/hxi_connector/common/config/properties/Application.java
@@ -30,11 +30,13 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public final class Application
+@Validated
+public class Application
 {
     private @NotNull String sourceId;
     private @NotNull String version;

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/config/IntegrationProperties.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/config/IntegrationProperties.java
@@ -58,6 +58,7 @@ public class IntegrationProperties
     @NotNull private final HylandExperience hylandExperience;
     @NotNull private final Application application;
 
+    @Validated
     @ConfigurationProperties("alfresco")
     public record Alfresco(
             @NotNull @NestedConfigurationProperty Repository repository,
@@ -66,6 +67,7 @@ public class IntegrationProperties
             @NotNull @NestedConfigurationProperty Filter filter)
     {}
 
+    @Validated
     @ConfigurationProperties("hyland-experience")
     public record HylandExperience(
             @NotNull @NestedConfigurationProperty Storage storage,

--- a/prediction-applier/src/main/java/org/alfresco/hxi_connector/prediction_applier/config/InsightPredictionsProperties.java
+++ b/prediction-applier/src/main/java/org/alfresco/hxi_connector/prediction_applier/config/InsightPredictionsProperties.java
@@ -29,9 +29,9 @@ package org.alfresco.hxi_connector.prediction_applier.config;
 import jakarta.validation.constraints.NotBlank;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
 import org.alfresco.hxi_connector.prediction_applier.exception.PredictionApplierRuntimeException;
-import org.springframework.validation.annotation.Validated;
 
 @Validated
 @ConfigurationProperties(prefix = "hyland-experience.insight.predictions")

--- a/prediction-applier/src/main/java/org/alfresco/hxi_connector/prediction_applier/config/InsightPredictionsProperties.java
+++ b/prediction-applier/src/main/java/org/alfresco/hxi_connector/prediction_applier/config/InsightPredictionsProperties.java
@@ -31,7 +31,9 @@ import jakarta.validation.constraints.NotBlank;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import org.alfresco.hxi_connector.prediction_applier.exception.PredictionApplierRuntimeException;
+import org.springframework.validation.annotation.Validated;
 
+@Validated
 @ConfigurationProperties(prefix = "hyland-experience.insight.predictions")
 @SuppressWarnings({"PMD.LongVariable", "PMD.UnusedAssignment"})
 public record InsightPredictionsProperties(


### PR DESCRIPTION
This PR is to fix the validation that didn't work at the application startup for some properties e.g. `alfresco.repository`, `hyland-experience.storage`.


Using `@Validated` annotation results in a CGLib proxy being created for a bean so removed `final` from the `Application` class.