### PR TITLE
[CIN-885] fix for delete event serialized issue

### DIFF
--- a/common-test/src/main/java/org/alfresco/hxi_connector/common/test/docker/util/DockerTags.java
+++ b/common-test/src/main/java/org/alfresco/hxi_connector/common/test/docker/util/DockerTags.java
@@ -50,7 +50,7 @@ public class DockerTags
     private static final String TRANSFORM_ROUTER_TAG_DEFAULT = "4.0.1";
     private static final String TRANSFORM_CORE_AIO_TAG_DEFAULT = "5.0.1";
     private static final String SFS_TAG_DEFAULT = "4.0.1";
-    private static final String HXI_CONNECTOR_TAG_DEFAULT = "1.0.0-SNAPSHOT";
+    private static final String HXI_CONNECTOR_TAG_DEFAULT = "1.0.2-SNAPSHOT";
     private static final String PROPERTIES_FILE = "docker-tags.properties";
 
     private static Properties properties;

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/DeleteRequestIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/DeleteRequestIntegrationTest.java
@@ -60,12 +60,14 @@ class DeleteRequestIntegrationTest extends E2ETestBase
 
         // then
         String expectedBody = """
-                {
-                    "objectId": "d71dd823-82c7-477c-8490-04cb0e826e65",
-                    "sourceId" : "alfresco-dummy-source-id-0a63de491876",
-                    "eventType": "delete",
-                    "sourceTimestamp": 1611656982995
-                }""";
+                [
+                  {
+                   "objectId": "d71dd823-82c7-477c-8490-04cb0e826e65",
+                   "sourceId" : "alfresco-dummy-source-id-0a63de491876",
+                   "eventType": "delete",
+                   "sourceTimestamp": 1611656982995
+                  }
+                ]""";
         containerSupport.expectHxIngestMessageReceived(expectedBody);
     }
 }

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/RequestFiltersIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/RequestFiltersIntegrationTest.java
@@ -1179,12 +1179,14 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
 
         // then send a delete event
         String expectedBody = """
-                  {
+                  [
+                    {
                       "objectId" : "d71dd823-82c7-477c-8490-04cb0e826e14",
                       "sourceId" : "alfresco-dummy-source-id-0a63de491876",
                       "sourceTimestamp": 1611656982995,
                       "eventType" : "delete"
                     }
+                  ]
                 """;
         containerSupport.expectHxIngestMessageReceived(expectedBody);
     }
@@ -1261,12 +1263,14 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
 
         // then send a delete event
         String expectedBody = """
-                  {
+                  [
+                    {
                       "objectId" : "d71dd823-82c7-477c-8490-04cb0e826e15",
                       "sourceId" : "alfresco-dummy-source-id-0a63de491876",
                       "sourceTimestamp" : 1611656982995,
                       "eventType" : "delete"
                     }
+                  ]
                 """;
         containerSupport.expectHxIngestMessageReceived(expectedBody);
     }

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/config/jackson/DeleteNodeEventSerializer.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/config/jackson/DeleteNodeEventSerializer.java
@@ -55,6 +55,7 @@ public class DeleteNodeEventSerializer extends StdSerializer<DeleteNodeEvent>
     {
         try
         {
+            jgen.writeStartArray();
             jgen.writeStartObject();
 
             jgen.writeStringField("objectId", event.getObjectId());
@@ -63,6 +64,7 @@ public class DeleteNodeEventSerializer extends StdSerializer<DeleteNodeEvent>
             jgen.writeStringField("eventType", serializeEventType(event.getEventType()));
 
             jgen.writeEndObject();
+            jgen.writeEndArray();
         }
         catch (Exception e)
         {


### PR DESCRIPTION
https://hyland.atlassian.net/browse/CIN-885
Inside hxi connector for alfresco delete node event is not serialized as an array and because of that delete request is failing with an array body. 

Because of this issue test for delete case is failing in another pr:
https://github.com/Alfresco/hxinsight-connector/pull/767