### PR TITLE
[CIN-1052] disable pre_commit for schedule triggered job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ env:
 jobs:
   pre_commit:
     runs-on: ubuntu-latest
+    if: github.event_name != 'schedule'
     outputs:
       java_version: ${{ env.JAVA_VERSION }}
       java_version_supported_by_repo: ${{ env.JAVA_VERSION_SUPPORTED_BY_REPO }}


### PR DESCRIPTION
https://hyland.atlassian.net/browse/CIN-1052

Disable pre_commit for schedule triggered job as Alfresco/alfresco-build-tools/.github/actions/github-list-changes action does not contain 'schedule' event name - does not supported it