### PR TITLE
[CIN-1052] skip publish_snapshot_artifacts job when nightly tests are run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,6 +298,7 @@ jobs:
       !(failure() || cancelled()) &&
       (github.ref_name == 'master' || startsWith(github.ref_name, 'release/')) &&
       github.event_name != 'pull_request' &&
+      github.event_name != 'schedule' &&
       !contains(github.event.head_commit.message, '[skip build]')
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
https://hyland.atlassian.net/browse/CIN-1052

Disable publish_snapshot_artifacts job run when scheduled nightly tests are run