### PR TITLE
[CIN-1802] Disable failing tests from OpenApiRequestValidationTest due to schema update

### DIFF
--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/OpenApiRequestValidationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/OpenApiRequestValidationTest.java
@@ -44,6 +44,7 @@ import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.parser.core.models.ParseOptions;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.alfresco.hxi_connector.live_ingester.util.insight_api.HxInsightRequest;
@@ -85,6 +86,7 @@ public class OpenApiRequestValidationTest
         assertThat(openApiInteractionValidator.validateRequest(request).getMessages()).isEmpty();
     }
 
+    @Disabled("This test is disabled because the OpenApi Specification update is not finished yet.")
     @SneakyThrows
     @Test
     void testCreateRequestToIngestionEvents()
@@ -98,6 +100,7 @@ public class OpenApiRequestValidationTest
         assertThat(schemaValidator.validate(propertiesNode.toString(), propertiesSchema, null).getMessages()).isEmpty();
     }
 
+    @Disabled("This test is disabled because the OpenApi Specification update is not finished yet.")
     @SneakyThrows
     @Test
     void testUpdateRequestToIngestionEvents()


### PR DESCRIPTION
https://hyland.atlassian.net/browse/CIN-1802

PR to disable failing tests from OpenApiRequestValidationTest because of schema changes in /ingestion-events endpoint are not finished yet.
Tests should be enabled again after update of the OpenAPI Specification will be finished completely 