### PR TITLE
Check second time, Vercode vulnerabilities with an older version of Spring Boot 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: Alfresco/alfresco-build-tools/.github/actions/pre-commit@v8.14.1
 
   veracode_sca:
-    name: "Veracode - Source Clear Scan (SCA)"
+    name: "Veracode - Source Clear Scan (SCA) "
     runs-on: ubuntu-latest
     needs:
       - pre_commit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,15 +35,15 @@ jobs:
       java_version: ${{ env.JAVA_VERSION }}
       java_version_supported_by_repo: ${{ env.JAVA_VERSION_SUPPORTED_BY_REPO }}
     steps:
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v8.2.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v8.14.1
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - id: changed-files
-        uses: Alfresco/alfresco-build-tools/.github/actions/github-list-changes@v8.2.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/github-list-changes@v8.14.1
         with:
           write-list-to-env: true
-      - uses: Alfresco/alfresco-build-tools/.github/actions/pre-commit@v8.2.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/pre-commit@v8.14.1
 
   veracode_sca:
     name: "Veracode - Source Clear Scan (SCA)"
@@ -55,9 +55,9 @@ jobs:
       !contains(github.event.head_commit.message, '[skip build]')
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v8.2.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v8.2.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/veracode@v8.2.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v8.14.1
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v8.14.1
+      - uses: Alfresco/alfresco-build-tools/.github/actions/veracode@v8.14.1
         continue-on-error: true
         with:
           srcclr-api-token: ${{ secrets.SRCCLR_API_TOKEN }}
@@ -73,8 +73,8 @@ jobs:
       !contains(github.event.head_commit.message, '[skip build]')
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v8.2.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/github-download-file@v8.2.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v8.14.1
+      - uses: Alfresco/alfresco-build-tools/.github/actions/github-download-file@v8.14.1
         with:
           token: ${{ secrets.BOT_GITHUB_TOKEN }}
           repository: "Alfresco/veracode-baseline-archive"
@@ -108,8 +108,8 @@ jobs:
       !contains(github.event.head_commit.message, '[skip tests]')
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v8.2.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v8.2.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v8.14.1
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v8.14.1
       - uses: Alfresco/ya-pmd-scan@v4.1.0
 
   test_application:
@@ -128,14 +128,14 @@ jobs:
                       "live-ingester", "prediction-applier", "hxinsight-extension" ]
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v8.2.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v8.14.1
       - name: "Login to Quay.io"
         uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v8.2.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v8.14.1
       - name: "Test application"
         run: mvn ${{ env.MAVEN_CLI_OPTS }} clean verify -pl '${{ matrix.subproject }}' -am
 
@@ -154,14 +154,14 @@ jobs:
         repoVersion: [ 7.3.2, 7.4.2, 23.3.0 ]
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v8.2.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v8.14.1
       - name: "Login to Quay.io"
         uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v8.2.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v8.14.1
       - name: "Build application with distribution profile"
         run: mvn ${{ env.MAVEN_CLI_OPTS }} clean install -DskipTests -Dalfresco-platform.version=${{ matrix.repoVersion }}
 
@@ -181,14 +181,14 @@ jobs:
         repoVersion: [ 7.3.2, 7.4.2, 23.3.0 ]
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v8.2.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v8.14.1
       - name: "Login to Quay.io"
         uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v8.2.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v8.14.1
       - name: "Build application"
         run: mvn ${{ env.MAVEN_CLI_OPTS }} clean install -DskipTests -Dalfresco-platform.version=${{ matrix.repoVersion }}
       - name: "Build docker images"
@@ -214,14 +214,14 @@ jobs:
         repoVersion: [ 7.3.2, 7.4.2 ]
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v8.2.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v8.14.1
       - name: "Login to Quay.io"
         uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v8.2.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v8.14.1
       - name: "Build application"
         run: mvn ${{ env.MAVEN_CLI_OPTS }} clean install -DskipTests -Dalfresco-platform.version=${{ matrix.repoVersion }} -Dalfresco-platform.java.version=${{ env.JAVA_VERSION_SUPPORTED_BY_REPO }}
       - name: "Build docker images"
@@ -251,8 +251,8 @@ jobs:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v8.2.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v8.2.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v8.14.1
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v8.14.1
       - name: "Build application"
         run: mvn ${{ env.MAVEN_CLI_OPTS }} clean install -DskipTests -Dalfresco-platform.java.version=${{ env.JAVA_VERSION_SUPPORTED_BY_REPO }}
       - name: "Push docker images"
@@ -276,9 +276,9 @@ jobs:
       !contains(github.event.head_commit.message, '[skip build]')
     steps:
       - uses: actions/checkout@v4
-      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v8.2.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v8.2.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v8.2.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/get-build-info@v8.14.1
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v8.14.1
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v8.14.1
       - name: "Publish SNAPSHOT artifacts"
         timeout-minutes: ${{ fromJSON(env.GITHUB_ACTIONS_DEPLOY_TIMEOUT) }}
         run: mvn ${{ env.MAVEN_CLI_OPTS }} deploy -DskipTests -Dalfresco-platform.java.version=${{ env.JAVA_VERSION_SUPPORTED_BY_REPO }}
@@ -301,9 +301,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v8.2.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v8.2.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/configure-git-author@v8.2.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v8.14.1
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v8.14.1
+      - uses: Alfresco/alfresco-build-tools/.github/actions/configure-git-author@v8.14.1
         with:
           username: ${{ secrets.BOT_GITHUB_USERNAME }}
           email: ${{ secrets.BOT_GITHUB_EMAIL }}
@@ -353,8 +353,8 @@ jobs:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v8.2.0
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v8.2.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v8.14.1
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v8.14.1
       - name: "Build application"
         run: mvn ${{ env.MAVEN_CLI_OPTS }} clean install -DskipTests -Dproject.revision.key=${{ github.sha }} -Dalfresco-platform.java.version=${{ env.JAVA_VERSION_SUPPORTED_BY_REPO }}
       - name: "Deploy release version to quay.io"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - pre_commit
-    if: >
-      (github.ref_name == 'master' || startsWith(github.ref_name, 'release/') || github.event_name == 'pull_request') &&
-      !contains(github.event.head_commit.message, '[skip build]')
     steps:
       - uses: actions/checkout@v4
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v8.14.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,10 +64,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - pre_commit
-    if: >
-      (github.ref_name == 'master' || startsWith(github.ref_name, 'release/') || github.event_name == 'pull_request') &&
-      github.actor != 'dependabot[bot]' &&
-      !contains(github.event.head_commit.message, '[skip build]')
     steps:
       - uses: actions/checkout@v4
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v8.14.1

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <url>http://github.com/${project.scm.organization}/${project.scm.repository}</url>
         <connection>scm:git:https://github.com/${project.scm.organization}/${project.scm.repository}.git</connection>
         <developerConnection>scm:git:https://github.com/${project.scm.organization}/${project.scm.repository}.git</developerConnection>
-        <tag>1.0.1</tag>
+        <tag>HEAD</tag>
     </scm>
     <issueManagement>
         <system>Jira</system>


### PR DESCRIPTION
Continuation of the PR:
https://github.com/Alfresco/hxinsight-connector/pull/871

https://hyland.atlassian.net/browse/CIN-2089

In order to check if Veracode CI scans are able to detect spring-boot vulnerabilities:
CVE-2024-12801
CVE-2024-50379
CVE-2024-38827

on 1.0.1 hxinsight-connector version, where Spring Boot version is 3.3.5