### PR TITLE
[CIN-2351] Set Veracode SAST scan for project code only

### DIFF
--- a/.github/workflows/nightly_tests_and_veracode.yml
+++ b/.github/workflows/nightly_tests_and_veracode.yml
@@ -3,6 +3,7 @@ name: Veracode and Nightly Tests run
 on:
   pull_request:
     branches:
+      - feature/**
       - master
       - release/**
 
@@ -36,7 +37,7 @@ jobs:
     name: "Pipeline SAST Scan"
     runs-on: ubuntu-latest
     if: >
-      (github.ref_name == 'master' || startsWith(github.ref_name, 'release/') || github.event_name == 'schedule') &&
+      (github.ref_name == 'master' || startsWith(github.ref_name, 'release/') || github.event_name == 'pull_request') &&
       github.actor != 'dependabot[bot]' &&
       !contains(github.event.head_commit.message, '[skip build]')
     steps:


### PR DESCRIPTION
https://hyland.atlassian.net/browse/CIN-2351

feature/** in branches and pull_request condition instead of schedule are used for demonstration purpose only - its temporary and will be removed after acceptance

We should not perform any Veracode SAST scan on code which we don't maintain (e.g. coming from an external library), it should scan only jxinsight-connector modules