### PR TITLE
[CIN-2468] Remove datetime type from createdAt and modifiedAt properties

### DIFF
--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/bulk_ingester/BulkIngesterEventIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/bulk_ingester/BulkIngesterEventIntegrationTest.java
@@ -73,8 +73,8 @@ public class BulkIngesterEventIntegrationTest extends E2ETestBase
                     "sourceTimestamp": 1707153500,
                     "properties" : {
                       "type": {"value": "cm:category", "annotation": "type"},
-                      "createdAt": {"value": "2024-02-05T05:19:00.000Z", "type": "datetime", "annotation": "dateCreated"},
-                      "modifiedAt": {"value": "2025-02-05T05:19:00.000Z", "type": "datetime", "annotation": "dateModified"},
+                      "createdAt": {"value": "2024-02-05T05:19:00.000Z", "annotation": "dateCreated"},
+                      "modifiedAt": {"value": "2025-02-05T05:19:00.000Z", "annotation": "dateModified"},
                       "createdBy": {"value": "System", "annotation": "createdBy"},
                       "modifiedBy": {"value": "admin", "annotation": "modifiedBy"},
                       "aspectsNames": {"value": ["cm:auditable"], "annotation": "aspects"},
@@ -134,8 +134,8 @@ public class BulkIngesterEventIntegrationTest extends E2ETestBase
                       "createdBy": {"value": "admin", "annotation": "createdBy"},
                       "modifiedBy": {"value": "hr_user", "annotation": "modifiedBy"},
                       "aspectsNames": {"value": ["cm:indexControl", "cm:auditable"], "annotation": "aspects"},
-                      "createdAt": {"value": "2011-06-14T02:16:56.000Z", "type": "datetime", "annotation": "dateCreated"},
-                      "modifiedAt": {"value": "2011-06-15T02:16:56.000Z", "type": "datetime", "annotation": "dateModified"},
+                      "createdAt": {"value": "2011-06-14T02:16:56.000Z", "annotation": "dateCreated"},
+                      "modifiedAt": {"value": "2011-06-15T02:16:56.000Z", "annotation": "dateModified"},
                       "cm:name": {
                         "value": "dashboard.xml",
                         "annotation" : "name"

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/bulk_ingester/BulkIngesterEventMatchingContentMappingIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/bulk_ingester/BulkIngesterEventMatchingContentMappingIntegrationTest.java
@@ -90,8 +90,8 @@ public class BulkIngesterEventMatchingContentMappingIntegrationTest extends E2ET
                       "createdBy": {"value": "admin", "annotation": "createdBy"},
                       "modifiedBy": {"value": "hr_user", "annotation": "modifiedBy"},
                       "aspectsNames": {"value": ["cm:indexControl", "cm:auditable"], "annotation": "aspects"},
-                      "createdAt": {"value": "2011-06-14T02:16:56.000Z", "type": "datetime", "annotation": "dateCreated"},
-                      "modifiedAt": {"value": "2011-06-15T02:16:56.000Z", "type": "datetime", "annotation": "dateModified"},
+                      "createdAt": {"value": "2011-06-14T02:16:56.000Z", "annotation": "dateCreated"},
+                      "modifiedAt": {"value": "2011-06-15T02:16:56.000Z", "annotation": "dateModified"},
                       "cm:name": {
                         "value": "dashboard.xml",
                         "annotation" : "name"
@@ -180,8 +180,8 @@ public class BulkIngesterEventMatchingContentMappingIntegrationTest extends E2ET
                       "createdBy": {"value": "admin", "annotation": "createdBy"},
                       "modifiedBy": {"value": "hr_user", "annotation": "modifiedBy"},
                       "aspectsNames": {"value": ["cm:indexControl", "cm:auditable"], "annotation": "aspects"},
-                      "createdAt": {"value": "2011-06-14T02:16:56.000Z", "type": "datetime", "annotation": "dateCreated"},
-                      "modifiedAt": {"value": "2011-06-15T02:16:56.000Z", "type": "datetime", "annotation": "dateModified"},
+                      "createdAt": {"value": "2011-06-14T02:16:56.000Z", "annotation": "dateCreated"},
+                      "modifiedAt": {"value": "2011-06-15T02:16:56.000Z", "annotation": "dateModified"},
                       "cm:name": {
                         "value": "dashboard.xml",
                         "annotation" : "name"

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/bulk_ingester/BulkIngesterEventNonMatchingContentMappingIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/bulk_ingester/BulkIngesterEventNonMatchingContentMappingIntegrationTest.java
@@ -84,8 +84,8 @@ public class BulkIngesterEventNonMatchingContentMappingIntegrationTest extends E
                       "createdBy": {"value": "admin", "annotation": "createdBy"},
                       "modifiedBy": {"value": "hr_user", "annotation": "modifiedBy"},
                       "aspectsNames": {"value": ["cm:indexControl", "cm:auditable"], "annotation": "aspects"},
-                      "createdAt": {"value": "2011-06-14T02:16:56.000Z", "type": "datetime", "annotation": "dateCreated"},
-                      "modifiedAt": {"value": "2011-06-15T02:16:56.000Z", "type": "datetime", "annotation": "dateModified"},
+                      "createdAt": {"value": "2011-06-14T02:16:56.000Z", "annotation": "dateCreated"},
+                      "modifiedAt": {"value": "2011-06-15T02:16:56.000Z", "annotation": "dateModified"},
                       "cm:name": {
                         "value": "dashboard.xml",
                         "annotation" : "name"

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/MatchingContentMappingRequestIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/MatchingContentMappingRequestIntegrationTest.java
@@ -104,8 +104,8 @@ public class MatchingContentMappingRequestIntegrationTest extends E2ETestBase
                     "sourceTimestamp" : 1611227656423,
                     "properties": {
                       "cm:autoVersion": {"type": "boolean", "value": true},
-                      "createdAt": {"value": "2021-01-21T11:14:15.695Z", "type" : "datetime", "annotation": "dateCreated"},
-                      "modifiedAt": {"value" : "2021-01-21T11:14:15.695Z", "type" : "datetime", "annotation": "dateModified"},
+                      "createdAt": {"value": "2021-01-21T11:14:15.695Z", "annotation": "dateCreated"},
+                      "modifiedAt": {"value" : "2021-01-21T11:14:15.695Z", "annotation": "dateModified"},
                       "cm:versionType": {"type": "string", "value": "MAJOR"},
                       "aspectsNames": {"value": ["cm:versionable", "cm:auditable"], "annotation": "aspects"},
                       "cm:name": {
@@ -214,8 +214,8 @@ public class MatchingContentMappingRequestIntegrationTest extends E2ETestBase
                     "sourceTimestamp" : 1611227656423,
                     "properties": {
                       "cm:autoVersion": {"type": "boolean", "value": true},
-                      "createdAt": {"value": "2021-01-21T11:14:15.695Z", "type" : "datetime", "annotation": "dateCreated"},
-                      "modifiedAt": {"value": "2021-01-21T11:14:15.695Z", "type" : "datetime", "annotation": "dateModified"},
+                      "createdAt": {"value": "2021-01-21T11:14:15.695Z", "annotation": "dateCreated"},
+                      "modifiedAt": {"value": "2021-01-21T11:14:15.695Z", "annotation": "dateModified"},
                       "cm:versionType": {"type": "string", "value": "MAJOR"},
                       "aspectsNames": {"value": ["cm:versionable", "cm:auditable"], "annotation": "aspects"},
                       "cm:name": {

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/NonMatchingContentMappingRequestIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/NonMatchingContentMappingRequestIntegrationTest.java
@@ -100,8 +100,8 @@ class NonMatchingContentMappingRequestIntegrationTest extends E2ETestBase
                     "sourceTimestamp": 1611227656423,
                     "properties": {
                       "cm:autoVersion": {"type": "boolean", "value": true},
-                      "createdAt": {"value": "2021-01-21T11:14:15.695Z", "type" : "datetime", "annotation": "dateCreated"},
-                      "modifiedAt": {"value" : "2021-01-21T11:14:15.695Z", "type" : "datetime", "annotation": "dateModified"},
+                      "createdAt": {"value": "2021-01-21T11:14:15.695Z", "annotation": "dateCreated"},
+                      "modifiedAt": {"value" : "2021-01-21T11:14:15.695Z", "annotation": "dateModified"},
                       "cm:versionType": {"type": "string", "value": "MAJOR"},
                       "aspectsNames": {"value": ["cm:versionable", "cm:auditable"], "annotation": "aspects"},
                       "cm:name": {

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/PredictionRequestIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/PredictionRequestIntegrationTest.java
@@ -300,12 +300,10 @@ public class PredictionRequestIntegrationTest extends E2ETestBase
                     "properties": {
                        "createdAt" : {
                          "value" : "2021-01-21T11:14:15.695Z",
-                         "type": "datetime",
                          "annotation": "dateCreated"
                        },
                        "modifiedAt" : {
                          "value" : "2021-01-26T10:29:42.529Z",
-                         "type": "datetime",
                          "annotation": "dateModified"
                        },
                        "cm:versionLabel" : {

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/RequestFiltersIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/RequestFiltersIntegrationTest.java
@@ -108,8 +108,8 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                     "sourceTimestamp": 1611227656423,
                     "properties": {
                       "cm:autoVersion": {"type": "boolean", "value": true},
-                      "createdAt": {"value": "2024-03-02T11:14:15.695Z", "type" : "datetime", "annotation": "dateCreated"},
-                      "modifiedAt" : {"value" : "2024-03-06T11:14:15.695Z", "type" : "datetime", "annotation" : "dateModified"},
+                      "createdAt": {"value": "2024-03-02T11:14:15.695Z", "annotation": "dateCreated"},
+                      "modifiedAt" : {"value" : "2024-03-06T11:14:15.695Z", "annotation" : "dateModified"},
                       "cm:versionType": {"type": "string", "value": "MAJOR"},
                       "aspectsNames": {"value": ["cm:versionable", "cm:auditable"], "annotation": "aspects"},
                       "cm:name": {
@@ -267,8 +267,8 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                     "sourceTimestamp": 1611227656423,
                     "properties": {
                       "cm:autoVersion": {"type": "boolean", "value": true},
-                      "createdAt": {"value": "2024-03-02T11:14:15.695Z", "type" : "datetime", "annotation": "dateCreated"},
-                      "modifiedAt": {"value": "2024-03-06T11:14:15.695Z", "type" : "datetime", "annotation": "dateModified"},
+                      "createdAt": {"value": "2024-03-02T11:14:15.695Z", "annotation": "dateCreated"},
+                      "modifiedAt": {"value": "2024-03-06T11:14:15.695Z", "annotation": "dateModified"},
                       "cm:versionType": {"type": "string", "value": "MAJOR"},
                       "aspectsNames": {"value": ["cm:versionable", "cm:auditable", "cm:classifiable"], "annotation": "aspects"},
                       "cm:name": {
@@ -435,12 +435,10 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                       "modifiedBy": {"value": "abeecher", "annotation": "modifiedBy"},
                       "createdAt" : {
                         "value" : "2024-03-02T11:14:15.695Z",
-                        "type" : "datetime",
                         "annotation" : "dateCreated"
                       },
                       "modifiedAt" : {
                         "value" : "2024-03-06T10:29:42.529Z",
-                        "type" : "datetime",
                         "annotation" : "dateModified"
                       },
                       "cm:versionLabel" : {
@@ -629,12 +627,10 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                       "modifiedBy": {"value": "abeecher", "annotation": "modifiedBy"},
                       "createdAt" : {
                         "value" : "2024-03-02T11:14:15.695Z",
-                        "type" : "datetime",
                         "annotation" : "dateCreated"
                       },
                       "modifiedAt" : {
                         "value" : "2024-03-06T10:29:42.529Z",
-                        "type" : "datetime",
                         "annotation" : "dateModified"
                       },
                       "cm:versionLabel" : {
@@ -1063,12 +1059,10 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                        },
                        "createdAt" : {
                          "value" : "2024-03-02T11:14:15.695Z",
-                         "type" : "datetime",
                          "annotation" : "dateCreated"
                        },
                        "modifiedAt" : {
                          "value" : "2024-03-06T10:29:42.529Z",
-                         "type" : "datetime",
                          "annotation" : "dateModified"
                        },
                        "cm:versionLabel" : {
@@ -1358,12 +1352,10 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                        },
                        "createdAt" : {
                          "value" : "2024-03-02T11:14:15.695Z",
-                         "type" : "datetime",
                          "annotation" : "dateCreated"
                        },
                        "modifiedAt" : {
                          "value" : "2024-03-06T10:29:42.529Z",
-                         "type" : "datetime",
                          "annotation" : "dateModified"
                        },
                        "createdBy" : {

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/UpdateRequestIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/UpdateRequestIntegrationTest.java
@@ -179,12 +179,10 @@ public class UpdateRequestIntegrationTest extends E2ETestBase
                             "properties": {
                               "createdAt" : {
                                 "value" : "2021-01-21T11:14:15.695Z",
-                                "type" : "datetime",
                                 "annotation" : "dateCreated"
                               },
                               "modifiedAt" : {
                                 "value" : "2021-01-21T11:14:15.695Z",
-                                "type" : "datetime",
                                 "annotation" : "dateModified"
                               },
                               "createdBy" : {
@@ -260,12 +258,10 @@ public class UpdateRequestIntegrationTest extends E2ETestBase
                       "cm:title": {"type": "string", "value": "Purchase Order"},
                       "createdAt" : {
                         "value" : "2021-01-21T11:14:15.695Z",
-                        "type" : "datetime",
                         "annotation" : "dateCreated"
                       },
                       "modifiedAt" : {
                         "value" : "2021-01-26T10:29:42.529Z",
-                        "type" : "datetime",
                         "annotation" : "dateModified"
                       },
                       "createdBy" : {
@@ -342,12 +338,10 @@ public class UpdateRequestIntegrationTest extends E2ETestBase
                       "cm:title": {"type": "string", "value": "Summary for year 2024"},
                       "createdAt" : {
                         "value" : "2021-01-21T11:14:15.695Z",
-                        "type" : "datetime",
                         "annotation" : "dateCreated"
                       },
                       "modifiedAt" : {
                         "value" : "2021-01-26T10:29:42.529Z",
-                        "type" : "datetime",
                         "annotation" : "dateModified"
                       },
                       "createdBy" : {
@@ -443,12 +437,10 @@ public class UpdateRequestIntegrationTest extends E2ETestBase
                       "cm:categories": {"type": "string", "value": ["a9f57ef6-2acf-4b2a-ae85-82cf552bec58"]},
                       "createdAt" : {
                         "value" : "2021-01-21T11:14:15.695Z",
-                        "type" : "datetime",
                         "annotation" : "dateCreated"
                       },
                       "modifiedAt" : {
                         "value" : "2021-01-26T10:29:42.529Z",
-                        "type" : "datetime",
                         "annotation" : "dateModified"
                       },
                       "createdBy" : {
@@ -691,12 +683,10 @@ public class UpdateRequestIntegrationTest extends E2ETestBase
                       },
                       "createdAt" : {
                         "value" : "2021-01-21T11:14:15.695Z",
-                        "type" : "datetime",
                         "annotation" : "dateCreated"
                       },
                       "modifiedAt" : {
                         "value" : "2021-01-21T11:14:15.695Z",
-                        "type" : "datetime",
                         "annotation" : "dateModified"
                       },
                       "createdBy" : {
@@ -837,12 +827,10 @@ public class UpdateRequestIntegrationTest extends E2ETestBase
                     },
                     "createdAt" : {
                       "value" : "2024-07-30T11:37:39.182Z",
-                      "type" : "datetime",
                       "annotation" : "dateCreated"
                     },
                     "modifiedAt" : {
                       "value" : "2024-07-31T10:31:48.541Z",
-                      "type" : "datetime",
                       "annotation" : "dateModified"
                     },
                     "createdBy" : {

--- a/live-ingester/src/integration-test/resources/rest/hxinsight/requests/create-or-update-document.yml
+++ b/live-ingester/src/integration-test/resources/rest/hxinsight/requests/create-or-update-document.yml
@@ -29,12 +29,10 @@ body: [
       },
       "createdAt": {
         "value": "2021-01-21T11:14:15.695Z",
-        "type": "datetime",
         "annotation": "dateCreated"
       },
       "modifiedAt": {
         "value": "2021-01-26T10:29:42.529Z",
-        "type": "datetime",
         "annotation": "dateModified"
       },
       "cm:versionType": {

--- a/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/config/jackson/UpdateNodeEventSerializer.java
+++ b/live-ingester/src/main/java/org/alfresco/hxi_connector/live_ingester/adapters/config/jackson/UpdateNodeEventSerializer.java
@@ -126,11 +126,9 @@ public class UpdateNodeEventSerializer extends StdSerializer<UpdateNodeEvent>
         switch (name)
         {
         case CREATED_AT:
-            jgen.writeObjectField("type", "datetime");
             jgen.writeObjectField("annotation", "dateCreated");
             break;
         case MODIFIED_AT:
-            jgen.writeObjectField("type", "datetime");
             jgen.writeObjectField("annotation", "dateModified");
             break;
         case ASPECTS_NAMES:

--- a/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/config/jackson/UpdateNodeEventSerializerTest.java
+++ b/live-ingester/src/test/java/org/alfresco/hxi_connector/live_ingester/adapters/config/jackson/UpdateNodeEventSerializerTest.java
@@ -119,8 +119,8 @@ class UpdateNodeEventSerializerTest
                     "eventType": "createOrUpdate",
                     "sourceTimestamp": 1724225729830,
                     "properties": {
-                      "createdAt": {"value": "2024-02-19T07:56:50.034Z", "type": "datetime", "annotation": "dateCreated"},
-                      "modifiedAt": {"value": "2025-02-19T07:56:50.034Z", "type": "datetime", "annotation": "dateModified"},
+                      "createdAt": {"value": "2024-02-19T07:56:50.034Z", "annotation": "dateCreated"},
+                      "modifiedAt": {"value": "2025-02-19T07:56:50.034Z", "annotation": "dateModified"},
                       "modifiedBy": {"value": "000-000-000", "annotation": "modifiedBy"}
                     }
                   }


### PR DESCRIPTION
Due to the `datetime` type not being implemented in the Ingestion API yet, we decided to remove the `datetime` type for now.