### PR TITLE
[CIN-2695] Veracode SCA fix for dependabot

### DIFF
--- a/.github/workflows/nightly_tests_and_veracode.yml
+++ b/.github/workflows/nightly_tests_and_veracode.yml
@@ -1,5 +1,8 @@
 name: Veracode and Nightly Tests run
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:
@@ -20,7 +23,9 @@ jobs:
   veracode_sca:
     name: "Veracode - Source Clear Scan (SCA)"
     runs-on: ubuntu-latest
-    secrets: inherit
+    permissions:
+      contents: read
+      security-events: write
     if: >
       (github.event_name == 'schedule' || github.actor == 'dependabot[bot]') &&
       !contains(github.event.head_commit.message, '[skip build]')

--- a/.github/workflows/nightly_tests_and_veracode.yml
+++ b/.github/workflows/nightly_tests_and_veracode.yml
@@ -1,8 +1,5 @@
 name: Veracode and Nightly Tests run
 
-permissions:
-  contents: read
-
 on:
   pull_request:
     branches:

--- a/.github/workflows/nightly_tests_and_veracode.yml
+++ b/.github/workflows/nightly_tests_and_veracode.yml
@@ -20,6 +20,7 @@ jobs:
   veracode_sca:
     name: "Veracode - Source Clear Scan (SCA)"
     runs-on: ubuntu-latest
+    secrets: inherit
     if: >
       (github.event_name == 'schedule' || github.actor == 'dependabot[bot]') &&
       !contains(github.event.head_commit.message, '[skip build]')

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -127,16 +127,6 @@
     }
   ],
   "results": {
-    ".github/workflows/nightly_tests_and_veracode.yml": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/nightly_tests_and_veracode.yml",
-        "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
-        "is_verified": false,
-        "line_number": 23,
-        "is_secret": false
-      }
-    ],
     "common-authentication/src/integration-test/java/org/alfresco/hxi_connector/common/adapters/auth/util/AuthUtils.java": [
       {
         "type": "JSON Web Token",

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -127,6 +127,16 @@
     }
   ],
   "results": {
+    ".github/workflows/nightly_tests_and_veracode.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/nightly_tests_and_veracode.yml",
+        "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
+        "is_verified": false,
+        "line_number": 23,
+        "is_secret": false
+      }
+    ],
     "common-authentication/src/integration-test/java/org/alfresco/hxi_connector/common/adapters/auth/util/AuthUtils.java": [
       {
         "type": "JSON Web Token",
@@ -306,5 +316,5 @@
       }
     ]
   },
-  "generated_at": "2025-02-07T12:55:07Z"
+  "generated_at": "2025-03-25T08:10:36Z"
 }


### PR DESCRIPTION
https://hyland.atlassian.net/browse/CIN-2695

${{ secrets.SRCCLR_API_TOKEN }} is not available in veracode-sca job when its triggered by the dependabot actor, same secret is available when the job runs on schedule 