### PR TITLE
[CIN-2695] Fix for dependabot Veracode SCA

### DIFF
--- a/.github/workflows/nightly_tests_and_veracode.yml
+++ b/.github/workflows/nightly_tests_and_veracode.yml
@@ -3,13 +3,8 @@ name: Veracode and Nightly Tests run
 on:
   pull_request:
     branches:
-      - master
-      - release/**
+      - feature/**
 
-  push:
-    branches:
-      - master
-      - release/**
   schedule:
     - cron: "0 0 * * *"  # Runs every night at midnight
 
@@ -20,12 +15,8 @@ jobs:
   veracode_sca:
     name: "Veracode - Source Clear Scan (SCA)"
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      security-events: write
-      id-token: write
     if: >
-      (github.event_name == 'schedule' || github.actor == 'dependabot[bot]') &&
+      github.event_name == 'pull_request' &&
       !contains(github.event.head_commit.message, '[skip build]')
     steps:
       - uses: actions/checkout@v4
@@ -39,7 +30,7 @@ jobs:
         with:
           srcclr-api-token: ${{ secrets.SRCCLR_API_TOKEN }}
       - name: "Notify on failure"
-        if: failure() && github.event_name == 'schedule'
+        if: failure()
         uses: Alfresco/alfresco-build-tools/.github/actions/send-teams-notification@v8.14.1
         with:
           webhook-url: ${{ secrets.MS_TEAMS_WEBHOOK_URL }}

--- a/.github/workflows/nightly_tests_and_veracode.yml
+++ b/.github/workflows/nightly_tests_and_veracode.yml
@@ -1,10 +1,6 @@
 name: Veracode and Nightly Tests run
 
 on:
-  push:
-    branches:
-      - feature/**
-
   schedule:
     - cron: "0 0 * * *"  # Runs every night at midnight
 
@@ -15,7 +11,6 @@ jobs:
   veracode_sca:
     name: "Veracode - Source Clear Scan (SCA)"
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || github.event_name == 'push'
     steps:
       - uses: actions/checkout@v4
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v8.14.1
@@ -37,7 +32,6 @@ jobs:
   nightly_tests:
     name: "Run nightly tests"
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule'
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v4

--- a/.github/workflows/nightly_tests_and_veracode.yml
+++ b/.github/workflows/nightly_tests_and_veracode.yml
@@ -20,8 +20,7 @@ jobs:
     name: "Veracode - Source Clear Scan (SCA)"
     runs-on: ubuntu-latest
     if: >
-      github.event_name == 'pull_request' &&
-      !contains(github.event.head_commit.message, '[skip build]')
+      github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v8.14.1

--- a/.github/workflows/nightly_tests_and_veracode.yml
+++ b/.github/workflows/nightly_tests_and_veracode.yml
@@ -1,10 +1,6 @@
 name: Veracode and Nightly Tests run
 
 on:
-  pull_request:
-    branches:
-      - feature/**
-
   push:
     branches:
       - feature/**
@@ -19,7 +15,7 @@ jobs:
   veracode_sca:
     name: "Veracode - Source Clear Scan (SCA)"
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'schedule' || github.event_name == 'push'
     steps:
       - uses: actions/checkout@v4
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v8.14.1

--- a/.github/workflows/nightly_tests_and_veracode.yml
+++ b/.github/workflows/nightly_tests_and_veracode.yml
@@ -19,8 +19,7 @@ jobs:
   veracode_sca:
     name: "Veracode - Source Clear Scan (SCA)"
     runs-on: ubuntu-latest
-    if: >
-      github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4
       - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v8.14.1

--- a/.github/workflows/nightly_tests_and_veracode.yml
+++ b/.github/workflows/nightly_tests_and_veracode.yml
@@ -23,6 +23,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      id-token: write
     if: >
       (github.event_name == 'schedule' || github.actor == 'dependabot[bot]') &&
       !contains(github.event.head_commit.message, '[skip build]')

--- a/.github/workflows/nightly_tests_and_veracode.yml
+++ b/.github/workflows/nightly_tests_and_veracode.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - feature/**
 
+  push:
+    branches:
+      - feature/**
+
   schedule:
     - cron: "0 0 * * *"  # Runs every night at midnight
 


### PR DESCRIPTION
https://hyland.atlassian.net/browse/CIN-2695

${{ secrets.SRCCLR_API_TOKEN }} is not available in veracode-sca job when its triggered by the dependabot actor, same secret is available when the job runs on schedule

id-token: write -> fetch an OpenID Connect (OIDC) token
