### PR TITLE
[CIN-2773] Property type is failing OpenApi validation

### DIFF
--- a/live-ingester/src/integration-test/resources/rest/hxinsight/requests/create-or-update-document.yml
+++ b/live-ingester/src/integration-test/resources/rest/hxinsight/requests/create-or-update-document.yml
@@ -48,7 +48,7 @@ body: [
           "namespaceURI": "http://www.alfresco.org/model/content/1.0",
           "localName": "content",
           "prefixString": "content"
-        },
+         },
         "type": "string"
       },
       "createdBy": {

--- a/live-ingester/src/integration-test/resources/rest/hxinsight/requests/create-or-update-document.yml
+++ b/live-ingester/src/integration-test/resources/rest/hxinsight/requests/create-or-update-document.yml
@@ -43,6 +43,14 @@ body: [
         "type": "string",
         "value": "1.0"
       },
+      "cm:contentPropertyName": {
+        "value": {
+          "namespaceURI": "http://www.alfresco.org/model/content/1.0",
+          "localName": "content",
+          "prefixString": "content"
+        },
+        "type": "string"
+      },
       "createdBy": {
         "value": "admin",
         "annotation": "createdBy"


### PR DESCRIPTION
https://hyland.atlassian.net/browse/CIN-2773

"cm:contentPropertyName": {
                "value": {
                    "namespaceURI": "http://www.alfresco.org/model/content/1.0",
                    "localName": "content",
                    "prefixString": "content"
                },
                "type": "string"
            },
is failing OpenApi validation with response:

[400 Bad Request response.json](https://github.com/user-attachments/files/19485152/400.Bad.Request.response.json)

Idea is to fail a build in order to implement a fix for the issue 

