### PR TITLE
[CIN-3040] Update sourceId to UUID format 

### DIFF
--- a/e2e-test/src/test/java/org/alfresco/hxi_connector/e2e_test/AgentsE2eTest.java
+++ b/e2e-test/src/test/java/org/alfresco/hxi_connector/e2e_test/AgentsE2eTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco HX Insight Connector
  * %%
- * Copyright (C) 2023 - 2024 Alfresco Software Limited
+ * Copyright (C) 2023 - 2025 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * If the software was purchased under a paid Alfresco license, the terms of
@@ -93,7 +93,7 @@ public class AgentsE2eTest
         LoggedRequest loggedRequest = WireMock.findAll(WireMock.getRequestedFor(WireMock.anyUrl())).get(0);
 
         assertNotNull(loggedRequest);
-        assertEquals("/agents?sourceId=alfresco-dummy-source-id-0a63de491876", loggedRequest.getUrl());
+        assertEquals("/agents?sourceId=a1f3e7c0-d193-7023-ce1d-0a63de491876", loggedRequest.getUrl());
 
         assertEquals(SC_OK, response.statusCode());
         Map<String, String> expected0 = Map.of("name", "HR Policy Agent", "description", "This agent is responsible for HR policy predictions", "id", "61254576-62a3-453f-8cd8-19e2f6554f29", "avatarUrl", "https://s3.amazonaws.com/avatars/ecf13dd4-c061-462b-8122-e3203cc40a0d.jpg");

--- a/e2e-test/src/test/java/org/alfresco/hxi_connector/e2e_test/BulkIngesterE2eTest.java
+++ b/e2e-test/src/test/java/org/alfresco/hxi_connector/e2e_test/BulkIngesterE2eTest.java
@@ -90,7 +90,7 @@ public class BulkIngesterE2eTest
     {
         // given
         String nodeId = "02acf462-533d-4e1b-9825-05fa934140da";
-        String sourceId = "alfresco-dummy-source-id-0a63de491876";
+        String sourceId = "a1f3e7c0-d193-7023-ce1d-0a63de491876";
         String eventType = "createOrUpdate";
 
         // when

--- a/e2e-test/src/test/java/org/alfresco/hxi_connector/e2e_test/DeleteNodeE2eTest.java
+++ b/e2e-test/src/test/java/org/alfresco/hxi_connector/e2e_test/DeleteNodeE2eTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco HX Insight Connector
  * %%
- * Copyright (C) 2023 - 2024 Alfresco Software Limited
+ * Copyright (C) 2023 - 2025 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * If the software was purchased under a paid Alfresco license, the terms of
@@ -114,7 +114,7 @@ public class DeleteNodeE2eTest
         // then
         RetryUtils.retryWithBackoff(() -> WireMock.verify(exactly(1), postRequestedFor(urlEqualTo("/ingestion-events"))
                 .withRequestBody(containing("\"objectId\":\"%s\"".formatted(createdNode.id())))
-                .withRequestBody(containing("\"sourceId\":\"alfresco-dummy-source-id-0a63de491876\""))
+                .withRequestBody(containing("\"sourceId\":\"a1f3e7c0-d193-7023-ce1d-0a63de491876\""))
                 .withRequestBody(containing("\"sourceTimestamp\""))
                 .withRequestBody(containing("\"eventType\":\"delete\""))
                 .withHeader(USER_AGENT, matching(getAppInfoRegex()))), DELAY_MS);

--- a/hxinsight-extension/src/main/resources/alfresco/module/alfresco-hxinsight-connector-hxinsight-extension/alfresco-global.properties
+++ b/hxinsight-extension/src/main/resources/alfresco/module/alfresco-hxinsight-connector-hxinsight-extension/alfresco-global.properties
@@ -25,6 +25,6 @@ hxi.discovery.questions-endpoint=${hxi.discovery.base-url}/qna/integrations
 hxi.question.max-context-size-for-question=100
 
 hxi.connector.version="@project.version@"
-hxi.connector.source-id=alfresco-dummy-source-id-0a63de491876
+hxi.connector.source-id=a1f3e7c0-d193-7023-ce1d-0a63de491876
 
 hxi.knowledge-retrieval.url=http://dummy-host.xyz/knowledge-retrieval/bots

--- a/hxinsight-extension/src/test/java/org/alfresco/hxi_connector/hxi_extension/service/HxInsightClientTest.java
+++ b/hxinsight-extension/src/test/java/org/alfresco/hxi_connector/hxi_extension/service/HxInsightClientTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Alfresco HX Insight Connector
  * %%
- * Copyright (C) 2023 - 2024 Alfresco Software Limited
+ * Copyright (C) 2023 - 2025 Alfresco Software Limited
  * %%
  * This file is part of the Alfresco software.
  * If the software was purchased under a paid Alfresco license, the terms of
@@ -77,7 +77,7 @@ class HxInsightClientTest
     private static final String AGENT_ID = "agent-id";
     private static final Set<String> OBJECT_IDS = Set.of("dummy-node-id");
     private static final String USER_AGENT_HEADER = "ACS HXI Connector/1.0.0 ACS/23.2.0 (Windows 10 amd64)";
-    private static final String SOURCE_ID = "alfresco-dummy-source-id-0a63de491876";
+    private static final String SOURCE_ID = "a1f3e7c0-d193-7023-ce1d-0a63de491876";
     private final HxInsightClientConfig config = new HxInsightClientConfig("http://hxinsight", "http://hxinsight");
     private final AuthService authService = mock(AuthService.class);
     private final ObjectMapper objectMapper = new ObjectMapper();

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/hx_insight/HxInsightEventPublisherIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/hx_insight/HxInsightEventPublisherIntegrationTest.java
@@ -67,13 +67,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -129,7 +129,7 @@ class HxInsightEventPublisherIntegrationTest extends IntegrationCamelTestBase
     @SuppressWarnings("PMD.FieldNamingConventions")
     static final WireMockContainer wireMockServer = DockerContainers.createWireMockContainer();
 
-    @SpyBean
+    @MockitoSpyBean
     IngestionEngineEventPublisher ingestionEngineEventPublisher;
 
     @BeforeAll
@@ -253,7 +253,7 @@ class HxInsightEventPublisherIntegrationTest extends IntegrationCamelTestBase
         @Bean
         public Application application()
         {
-            return new Application("alfresco-dummy-source-id-0a63de491876", DockerTags.getHxiConnectorTag());
+            return new Application("a1f3e7c0-d193-7023-ce1d-0a63de491876", DockerTags.getHxiConnectorTag());
         }
 
         @Bean

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/hx_insight/storage/connector/PreSignedUrlRequesterIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/adapters/messaging/hx_insight/storage/connector/PreSignedUrlRequesterIntegrationTest.java
@@ -342,7 +342,7 @@ class PreSignedUrlRequesterIntegrationTest extends IntegrationCamelTestBase
         @Bean
         public Application application()
         {
-            return new Application("alfresco-dummy-source-id-0a63de491876", DockerTags.getHxiConnectorTag());
+            return new Application("a1f3e7c0-d193-7023-ce1d-0a63de491876", DockerTags.getHxiConnectorTag());
         }
 
         @Bean

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/bulk_ingester/BulkIngesterEventIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/bulk_ingester/BulkIngesterEventIntegrationTest.java
@@ -68,7 +68,7 @@ public class BulkIngesterEventIntegrationTest extends E2ETestBase
                 [
                   {
                     "objectId" : "5018ff83-ec45-4a11-95c4-681761752aa7",
-                    "sourceId" : "alfresco-dummy-source-id-0a63de491876",
+                    "sourceId" : "a1f3e7c0-d193-7023-ce1d-0a63de491876",
                     "eventType" : "createOrUpdate",
                     "sourceTimestamp": 1707153500,
                     "properties" : {
@@ -126,7 +126,7 @@ public class BulkIngesterEventIntegrationTest extends E2ETestBase
                 [
                   {
                     "objectId" : "37be157c-741c-4e51-b781-20d36e4e335a",
-                    "sourceId" : "alfresco-dummy-source-id-0a63de491876",
+                    "sourceId" : "a1f3e7c0-d193-7023-ce1d-0a63de491876",
                     "eventType" : "createOrUpdate",
                     "sourceTimestamp": 1308061016,
                     "properties" : {

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/bulk_ingester/BulkIngesterEventMatchingContentMappingIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/bulk_ingester/BulkIngesterEventMatchingContentMappingIntegrationTest.java
@@ -82,7 +82,7 @@ public class BulkIngesterEventMatchingContentMappingIntegrationTest extends E2ET
                 [
                   {
                     "objectId" : "37be157c-741c-4e51-b781-20d36e4e335a",
-                    "sourceId" : "alfresco-dummy-source-id-0a63de491876",
+                    "sourceId" : "a1f3e7c0-d193-7023-ce1d-0a63de491876",
                     "eventType" : "createOrUpdate",
                     "sourceTimestamp": %s,
                     "properties" : {
@@ -172,7 +172,7 @@ public class BulkIngesterEventMatchingContentMappingIntegrationTest extends E2ET
                 [
                   {
                     "objectId" : "37be157c-741c-4e51-b781-20d36e4e335a",
-                    "sourceId" : "alfresco-dummy-source-id-0a63de491876",
+                    "sourceId" : "a1f3e7c0-d193-7023-ce1d-0a63de491876",
                     "eventType" : "createOrUpdate",
                     "sourceTimestamp": %s,
                     "properties" : {

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/bulk_ingester/BulkIngesterEventNonMatchingContentMappingIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/bulk_ingester/BulkIngesterEventNonMatchingContentMappingIntegrationTest.java
@@ -76,7 +76,7 @@ public class BulkIngesterEventNonMatchingContentMappingIntegrationTest extends E
                 [
                   {
                     "objectId" : "37be157c-741c-4e51-b781-20d36e4e335a",
-                    "sourceId" : "alfresco-dummy-source-id-0a63de491876",
+                    "sourceId" : "a1f3e7c0-d193-7023-ce1d-0a63de491876",
                     "eventType" : "createOrUpdate",
                     "sourceTimestamp" : %s,
                     "properties" : {

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/MatchingContentMappingRequestIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/MatchingContentMappingRequestIntegrationTest.java
@@ -99,7 +99,7 @@ public class MatchingContentMappingRequestIntegrationTest extends E2ETestBase
                 [
                   {
                     "objectId": "d71dd823-01c7-477c-8490-04cb0e826e61",
-                    "sourceId" : "alfresco-dummy-source-id-0a63de491876",
+                    "sourceId" : "a1f3e7c0-d193-7023-ce1d-0a63de491876",
                     "eventType": "createOrUpdate",
                     "sourceTimestamp" : 1611227656423,
                     "properties": {
@@ -209,7 +209,7 @@ public class MatchingContentMappingRequestIntegrationTest extends E2ETestBase
                 [
                   {
                     "objectId": "d71dd823-01c7-477c-8490-04cb0e826e61",
-                    "sourceId" : "alfresco-dummy-source-id-0a63de491876",
+                    "sourceId" : "a1f3e7c0-d193-7023-ce1d-0a63de491876",
                     "eventType": "createOrUpdate",
                     "sourceTimestamp" : 1611227656423,
                     "properties": {

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/NonMatchingContentMappingRequestIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/NonMatchingContentMappingRequestIntegrationTest.java
@@ -95,7 +95,7 @@ class NonMatchingContentMappingRequestIntegrationTest extends E2ETestBase
                 [
                   {
                     "objectId": "d71dd823-01c7-477c-8490-04cb0e826e61",
-                    "sourceId" : "alfresco-dummy-source-id-0a63de491876",
+                    "sourceId" : "a1f3e7c0-d193-7023-ce1d-0a63de491876",
                     "eventType": "createOrUpdate",
                     "sourceTimestamp": 1611227656423,
                     "properties": {

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/PredictionRequestIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/PredictionRequestIntegrationTest.java
@@ -295,7 +295,7 @@ public class PredictionRequestIntegrationTest extends E2ETestBase
                   {
                     "objectId": "34563456-3456-3456-3456-345634563456",
                     "eventType": "createOrUpdate",
-                    "sourceId" : "alfresco-dummy-source-id-0a63de491876",
+                    "sourceId" : "a1f3e7c0-d193-7023-ce1d-0a63de491876",
                     "sourceTimestamp" : %s,
                     "properties": {
                        "createdAt" : {
@@ -415,7 +415,7 @@ public class PredictionRequestIntegrationTest extends E2ETestBase
                 [
                   {
                     "objectId": "5f355d16-f824-4173-bf4b-b1ec37ef5549",
-                    "sourceId" : "alfresco-dummy-source-id-0a63de491876",
+                    "sourceId" : "a1f3e7c0-d193-7023-ce1d-0a63de491876",
                     "eventType": "createOrUpdate",
                     "sourceTimestamp": %s,
                     "properties": {

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/RequestFiltersIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/RequestFiltersIntegrationTest.java
@@ -103,7 +103,7 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                 [
                   {
                     "objectId": "d71dd823-82c7-477c-8490-04cb0e826e01",
-                    "sourceId" : "alfresco-dummy-source-id-0a63de491876",
+                    "sourceId" : "a1f3e7c0-d193-7023-ce1d-0a63de491876",
                     "eventType": "createOrUpdate",
                     "sourceTimestamp": 1611227656423,
                     "properties": {
@@ -262,7 +262,7 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                 [
                   {
                     "objectId": "d71dd823-82c7-477c-8490-04cb0e826e03",
-                    "sourceId" : "alfresco-dummy-source-id-0a63de491876",
+                    "sourceId" : "a1f3e7c0-d193-7023-ce1d-0a63de491876",
                     "eventType": "createOrUpdate",
                     "sourceTimestamp": 1611227656423,
                     "properties": {
@@ -426,7 +426,7 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                 [
                   {
                     "objectId": "d71dd823-82c7-477c-8490-04cb0e826e05",
-                    "sourceId" : "alfresco-dummy-source-id-0a63de491876",
+                    "sourceId" : "a1f3e7c0-d193-7023-ce1d-0a63de491876",
                     "eventType": "createOrUpdate",
                     "sourceTimestamp": 1611656982995,
                     "properties": {
@@ -618,7 +618,7 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                 [
                   {
                     "objectId": "d71dd823-82c7-477c-8490-04cb0e826e07",
-                    "sourceId" : "alfresco-dummy-source-id-0a63de491876",
+                    "sourceId" : "a1f3e7c0-d193-7023-ce1d-0a63de491876",
                     "eventType": "createOrUpdate",
                     "sourceTimestamp": 1611656982995,
                     "properties": {
@@ -1049,7 +1049,7 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                 [
                   {
                      "objectId" : "d71dd823-82c7-477c-8490-04cb0e826e13",
-                     "sourceId" : "alfresco-dummy-source-id-0a63de491876",
+                     "sourceId" : "a1f3e7c0-d193-7023-ce1d-0a63de491876",
                      "eventType" : "createOrUpdate",
                      "sourceTimestamp": 1611656982995,
                      "properties" : {
@@ -1181,7 +1181,7 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                   [
                     {
                       "objectId" : "d71dd823-82c7-477c-8490-04cb0e826e14",
-                      "sourceId" : "alfresco-dummy-source-id-0a63de491876",
+                      "sourceId" : "a1f3e7c0-d193-7023-ce1d-0a63de491876",
                       "sourceTimestamp": 1611656982995,
                       "eventType" : "delete"
                     }
@@ -1265,7 +1265,7 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                   [
                     {
                       "objectId" : "d71dd823-82c7-477c-8490-04cb0e826e15",
-                      "sourceId" : "alfresco-dummy-source-id-0a63de491876",
+                      "sourceId" : "a1f3e7c0-d193-7023-ce1d-0a63de491876",
                       "sourceTimestamp" : 1611656982995,
                       "eventType" : "delete"
                     }
@@ -1342,7 +1342,7 @@ public class RequestFiltersIntegrationTest extends E2ETestBase
                 [
                   {
                      "objectId" : "d71dd823-82c7-477c-8490-04cb0e826e16",
-                     "sourceId" : "alfresco-dummy-source-id-0a63de491876",
+                     "sourceId" : "a1f3e7c0-d193-7023-ce1d-0a63de491876",
                      "eventType" : "createOrUpdate",
                      "sourceTimestamp": 1611656982995,
                      "properties" : {

--- a/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/UpdateRequestIntegrationTest.java
+++ b/live-ingester/src/integration-test/java/org/alfresco/hxi_connector/live_ingester/domain/usecase/e2e/repository/UpdateRequestIntegrationTest.java
@@ -173,7 +173,7 @@ public class UpdateRequestIntegrationTest extends E2ETestBase
                         [
                           {
                             "objectId": "d71dd823-82c7-477c-8490-04cb0e826e65",
-                            "sourceId" : "alfresco-dummy-source-id-0a63de491876",
+                            "sourceId" : "a1f3e7c0-d193-7023-ce1d-0a63de491876",
                             "eventType": "createOrUpdate",
                             "sourceTimestamp": 1611656982995,
                             "properties": {
@@ -251,7 +251,7 @@ public class UpdateRequestIntegrationTest extends E2ETestBase
                 [
                   {
                     "objectId": "d71dd823-82c7-477c-8490-04cb0e826e65",
-                    "sourceId" : "alfresco-dummy-source-id-0a63de491876",
+                    "sourceId" : "a1f3e7c0-d193-7023-ce1d-0a63de491876",
                     "eventType": "createOrUpdate",
                     "sourceTimestamp": 1611656982995,
                     "properties": {
@@ -331,7 +331,7 @@ public class UpdateRequestIntegrationTest extends E2ETestBase
                 [
                   {
                     "objectId": "d71dd823-82c7-477c-8490-04cb0e826e65",
-                    "sourceId" : "alfresco-dummy-source-id-0a63de491876",
+                    "sourceId" : "a1f3e7c0-d193-7023-ce1d-0a63de491876",
                     "eventType": "createOrUpdate",
                     "sourceTimestamp": 1611656982995,
                     "properties": {
@@ -429,7 +429,7 @@ public class UpdateRequestIntegrationTest extends E2ETestBase
                 [
                   {
                     "objectId": "d71dd823-82c7-477c-8490-04cb0e826e65",
-                    "sourceId" : "alfresco-dummy-source-id-0a63de491876",
+                    "sourceId" : "a1f3e7c0-d193-7023-ce1d-0a63de491876",
                     "eventType": "createOrUpdate",
                     "sourceTimestamp": 1611656982995,
                     "properties": {
@@ -584,7 +584,7 @@ public class UpdateRequestIntegrationTest extends E2ETestBase
                 [
                   {
                     "objectId": "321d84e3-a5fe-431e-92f5-f8e09480305e",
-                    "sourceId" : "alfresco-dummy-source-id-0a63de491876",
+                    "sourceId" : "a1f3e7c0-d193-7023-ce1d-0a63de491876",
                     "eventType": "createOrUpdate",
                     "sourceTimestamp": 1704798873615,
                     "properties": {
@@ -685,7 +685,7 @@ public class UpdateRequestIntegrationTest extends E2ETestBase
                 [
                   {
                     "objectId": "82c7d723-1dd8-477c-8490-04cb0e826e65",
-                    "sourceId" : "alfresco-dummy-source-id-0a63de491876",
+                    "sourceId" : "a1f3e7c0-d193-7023-ce1d-0a63de491876",
                     "eventType": "createOrUpdate",
                     "sourceTimestamp" : 1611656982995,
                     "properties": {
@@ -810,7 +810,7 @@ public class UpdateRequestIntegrationTest extends E2ETestBase
         String expectedBody = """
                 [{
                   "objectId" : "9f3380e3-b9b1-4b01-b1c6-ef1f717a9abb",
-                  "sourceId" : "alfresco-dummy-source-id-0a63de491876",
+                  "sourceId" : "a1f3e7c0-d193-7023-ce1d-0a63de491876",
                   "eventType" : "createOrUpdate",
                   "sourceTimestamp" : 1722422055416,
                   "properties" : {

--- a/live-ingester/src/integration-test/resources/rest/hxinsight/requests/create-or-update-document.yml
+++ b/live-ingester/src/integration-test/resources/rest/hxinsight/requests/create-or-update-document.yml
@@ -7,7 +7,7 @@ headers:
 body: [
   {
     "objectId": "d71dd823-82c7-477c-8490-04cb0e826e65",
-    "sourceId": "alfresco-dummy-source-id-0a63de491876",
+    "sourceId": "a1f3e7c0-d193-7023-ce1d-0a63de491876",
     "eventType": "createOrUpdate",
     "sourceTimestamp": 1611656982995,
     "properties": {

--- a/live-ingester/src/integration-test/resources/rest/hxinsight/requests/create-thumbnail.yml
+++ b/live-ingester/src/integration-test/resources/rest/hxinsight/requests/create-thumbnail.yml
@@ -7,7 +7,7 @@ headers:
 body: [
   {
     "objectId": "2f794000-7b44-4bd7-b940-007b44ebd755",
-    "sourceId": "alfresco-dummy-source-id-0a63de491876",
+    "sourceId": "a1f3e7c0-d193-7023-ce1d-0a63de491876",
     "eventType": "createOrUpdate",
     "sourceTimestamp": 1743074879280,
     "properties": {

--- a/live-ingester/src/integration-test/resources/rest/hxinsight/requests/delete-document.yml
+++ b/live-ingester/src/integration-test/resources/rest/hxinsight/requests/delete-document.yml
@@ -7,7 +7,7 @@ headers:
 body: [
   {
     "objectId": "d71dd823-82c7-477c-8490-04cb0e826e65",
-    "sourceId" : "alfresco-dummy-source-id-0a63de491876",
+    "sourceId" : "a1f3e7c0-d193-7023-ce1d-0a63de491876",
     "eventType": "delete",
     "sourceTimestamp": 1611656982995
   }

--- a/live-ingester/src/integration-test/resources/rest/hxinsight/requests/upload-references-document.yml
+++ b/live-ingester/src/integration-test/resources/rest/hxinsight/requests/upload-references-document.yml
@@ -7,7 +7,7 @@ headers:
 body: [
   {
     "objectId": "d71dd823-82c7-477c-8490-04cb0e826e65",
-    "sourceId" : "alfresco-dummy-source-id-0a63de491876",
+    "sourceId" : "a1f3e7c0-d193-7023-ce1d-0a63de491876",
     "eventType": "createOrUpdate",
     "sourceTimestamp": 1611656982995,
     "properties": {

--- a/live-ingester/src/main/resources/application.yml
+++ b/live-ingester/src/main/resources/application.yml
@@ -12,7 +12,7 @@ camel:
   main.auto-startup: false
 
 application:
-  source-id: alfresco-dummy-source-id-0a63de491876
+  source-id: a1f3e7c0-d193-7023-ce1d-0a63de491876
   version: "@project.version@"
 
 alfresco:

--- a/prediction-applier/src/main/resources/application.yml
+++ b/prediction-applier/src/main/resources/application.yml
@@ -14,7 +14,7 @@ camel:
     auto-startup: false
 
 application:
-  source-id: alfresco-dummy-source-id-0a63de491876
+  source-id: a1f3e7c0-d193-7023-ce1d-0a63de491876
   version: "@project.version@"
 
 hyland-experience:


### PR DESCRIPTION
https://hyland.atlassian.net/browse/CIN-3040

Next to update of the sourceId value inside yaml files with request body which is validated against OpenApi Specification for Insight Ingestion, there are changes made to any sourceId (in hxinsight-connector project) with value:
"alfresco-dummy-source-id-0a63de491876"
which was not valid UUID format.

One change was made for 
'org.springframework.boot.test.mock.mockito.SpyBean' is deprecated since version 3.4.0 and marked for removal 
this was replaced by @MockitoSpyBean
