### PR TITLE
[CIN-4060] Bump spring-boot version from 3.4.4. to 3.4.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <alfresco-sdk.version>4.11.0</alfresco-sdk.version>
         <alfresco-db-connector.version>5.1.0-A.1</alfresco-db-connector.version>
         <alfresco-event-model.version>1.0.2</alfresco-event-model.version>
-        <spring-boot.version>3.4.4</spring-boot.version>
+        <spring-boot.version>3.4.5</spring-boot.version>
         <spring-camel.version>4.10.2</spring-camel.version>
         <commons-lang.version>3.17.0</commons-lang.version>
         <commons-collections.version>4.4</commons-collections.version>


### PR DESCRIPTION
https://hyland.atlassian.net/browse/CIN-4066

Upgrade spring-boot version from 3.4.4. to 3.4.5 in order to upgrade transitive dependencies versions that are dependent on main spring-boot dependency 