### PR TITLE
feat(CIN-4141): update connector to use ingest v2 api for metadata events

### DIFF
--- a/live-ingester/src/integration-test/resources/rest/hxinsight/requests/create-or-update-document.yml
+++ b/live-ingester/src/integration-test/resources/rest/hxinsight/requests/create-or-update-document.yml
@@ -1,4 +1,4 @@
-url: /v1/ingestion-events
+url: /v2/ingestion-events
 headers:
   authorization: string
   content-type: application/json

--- a/live-ingester/src/integration-test/resources/rest/hxinsight/requests/create-thumbnail.yml
+++ b/live-ingester/src/integration-test/resources/rest/hxinsight/requests/create-thumbnail.yml
@@ -1,4 +1,4 @@
-url: /v1/ingestion-events
+url: /v2/ingestion-events
 headers:
   authorization: string
   content-type: application/json

--- a/live-ingester/src/integration-test/resources/rest/hxinsight/requests/delete-document.yml
+++ b/live-ingester/src/integration-test/resources/rest/hxinsight/requests/delete-document.yml
@@ -1,4 +1,4 @@
-url: /v1/ingestion-events
+url: /v2/ingestion-events
 headers:
   authorization: string
   content-type: application/json

--- a/live-ingester/src/integration-test/resources/rest/hxinsight/requests/upload-references-document.yml
+++ b/live-ingester/src/integration-test/resources/rest/hxinsight/requests/upload-references-document.yml
@@ -1,4 +1,4 @@
-url: /v1/ingestion-events
+url: /v2/ingestion-events
 headers:
   authorization: string
   content-type: application/json


### PR DESCRIPTION
ingest api v2 is now used for ingestion-events