### PR TITLE
[CIN-4669] Update alfresco-db-connector version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
 
         <alfresco-platform.version>25.2.0-A.12</alfresco-platform.version>
         <alfresco-sdk.version>4.11.0</alfresco-sdk.version>
-        <alfresco-db-connector.version>5.1.0-A.4</alfresco-db-connector.version>
+        <alfresco-db-connector.version>5.1.1-A.2</alfresco-db-connector.version>
         <alfresco-event-model.version>1.0.2</alfresco-event-model.version>
         <spring-boot.version>3.5.0</spring-boot.version>
         <spring-camel.version>4.12.0</spring-camel.version>


### PR DESCRIPTION
https://hyland.atlassian.net/browse/CIN-4669

Update alfresco-db-connector version to 5.1.1-A2 , which contains transitive dependency postgresql with version 42.7.7 with the fix for the vulnerability CVE-2025-49146