### PR TITLE
[CIN-11964] Upgrade Spring Boot to 4.0.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <alfresco-sdk.version>4.15.0</alfresco-sdk.version>
         <alfresco-db-connector.version>1.2.0</alfresco-db-connector.version>
         <alfresco-event-model.version>1.0.11</alfresco-event-model.version>
-        <spring-boot.version>4.0.5</spring-boot.version>
+        <spring-boot.version>4.0.6</spring-boot.version>
         <spring-retry.version>2.0.12</spring-retry.version>
         <spring-camel.version>4.18.1</spring-camel.version>
         <commons-lang.version>3.20.0</commons-lang.version>


### PR DESCRIPTION
https://hyland.atlassian.net/browse/CIN-11964

Upgrade Spring Boot version to 4.0.6 as it contains upgrade for tomcat 11.0.21 that has path with fix for tomcat vulnerabilities mentioned in the ticket.

PR was created as for some reason dependabot upgrade is failing 
https://github.com/Alfresco/hxinsight-connector/pull/1375
even after revert of faulty tests:
https://github.com/Alfresco/hxinsight-connector/pull/1379
