### PR TITLE
[release] 2.2.1-A.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ env:
   # As the release is triggered by a commit message with "[release]" keyword on a release branch,
   # setting these variables to new values can be done in the same commit and will indicate the release and the dev versions in it.
   DEVELOPMENT_VERSION: "2.2.1-SNAPSHOT" # The version that will be set in pom files after the release (next dev version)
-  RELEASE_VERSION: "2.2.1-A.1" # The version of the release (tag).
+  RELEASE_VERSION: "2.2.1-A.2" # The version of the release (tag).
   GITHUB_ACTIONS_DEPLOY_TIMEOUT: 60
   MAVEN_CLI_OPTS: "-B -e -fae -V -DinstallAtEnd=true -DfailIfNoTests=false -U -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Pdistribution "
   MAVEN_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}


### PR DESCRIPTION
https://hyland.atlassian.net/browse/CIN-12692

Release Alfresco Connector v2.2.1-A.2 version containing code for CWE-117 Improper Output Neutralization for Logs

Veracode SAST does not see runtime Logback configuration and will keep flagging the raw log statements as CWE-117. Those findings will be marked as "Mitigated by Design" in the Veracode UI by user with admin rights from security team as they are informed via https://teams.microsoft.com/l/message/19:af1295facf724392b05161252687ef7c@thread.tacv2/1777966115027?tenantId=8ca5db88-a5ab-48f7-a5e0-4ce50935f807&groupId=7a627c98-e822-4d09-85a1-096fd29fe6e3&parentMessageId=1777966115027&teamName=Hyland%20-%20Alfresco&channelName=Ask-security&createdTime=1777966115027