### PR TITLE
ACS-11766 Migrate to GHAS, remove Veracode and fix CI Jolokia probe failure caused by ActiveMQ 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,28 +1,32 @@
 version: 2
 registries:
-  hylandsoftware-releases:
+  maven-alfresco-internal:
     type: maven-repository
-    url: https://artifacts.alfresco.com/nexus/content/repositories/hylandsoftware-releases
+    url: https://artifacts.alfresco.com/nexus/content/groups/internal
     username: ${{secrets.NEXUS_USERNAME}}
     password: ${{secrets.NEXUS_PASSWORD}}
 updates:
   - package-ecosystem: "maven"
     directory: "/"
     registries:
-      - hylandsoftware-releases
+      - maven-alfresco-internal
     schedule:
       interval: "daily"
       time: "22:00"
       timezone: "Europe/London"
-    open-pull-requests-limit: 99
+    open-pull-requests-limit: 10
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
   - package-ecosystem: docker
     directory: "distribution/src/main/resources"
     schedule:
       interval: daily
       time: "22:00"
       timezone: Europe/London
-    open-pull-requests-limit: 99
+    open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
       interval: "daily"
       time: "22:00"
       timezone: "Europe/London"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 99
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -29,4 +29,4 @@ updates:
       interval: daily
       time: "22:00"
       timezone: Europe/London
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 99

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,45 +45,6 @@ jobs:
         with:
           pre-commit-all-files: "false"
 
-  veracode_sast:
-    name: "Pipeline SAST Scan"
-    runs-on: ubuntu-latest
-    needs:
-      - pre_commit
-    if: >
-      (github.ref_name == 'master' || startsWith(github.ref_name, 'release/') || github.event_name == 'pull_request') &&
-      github.actor != 'dependabot[bot]' &&
-      !contains(github.event.head_commit.message, '[skip build]')
-    steps:
-      - uses: actions/checkout@v6
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v17.6.1
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-      - uses: Alfresco/alfresco-build-tools/.github/actions/github-download-file@v17.6.1
-        with:
-          token: ${{ secrets.BOT_GITHUB_TOKEN }}
-          repository: "Alfresco/veracode-baseline-archive"
-          file-path: "hxinsight-connector/hxinsight-connector-baseline.json"
-          target: "baseline.json"
-      - name: "Build application"
-        run: mvn ${{ env.MAVEN_CLI_OPTS }} clean install -DskipTests
-      - name: "Run SAST Scan"
-        uses: veracode/Veracode-pipeline-scan-action@v1.0.21
-        with:
-          vid: ${{ secrets.VERACODE_API_ID }}
-          vkey: ${{ secrets.VERACODE_API_KEY }}
-          file: "distribution/target/alfresco-hxinsight-connector-distribution-*.zip"
-          fail_build: true
-          project_name: hxinsight-connector
-          issue_details: true
-          veracode_policy_name: Alfresco Default
-          summary_display: true
-          baseline_file: baseline.json
-          include: "alfresco-hxinsight-connector*"
-          token: ""
-      - name: "Clean Maven cache"
-        run: bash ./scripts/ci/cleanup_cache.sh
-
   pmd_scan:
     name: "PMD Scan"
     runs-on: ubuntu-latest

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -1,0 +1,28 @@
+name: "Load Dependency Graph"
+on:
+  push:
+    branches:
+      - "master"
+      - "release/**"
+  schedule:
+    - cron: "0 6 * * *" # Every day at 6:00 UTC
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  scan-dependencies:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: Alfresco/alfresco-build-tools/.github/actions/maven-dependency-scan@v17.6.1
+        with:
+          java-version: '21'
+          maven-version: '3.9.9'
+          maven-args: -Dscopes=compile,runtime
+          maven-username: ${{ secrets.NEXUS_USERNAME }}
+          maven-password: ${{ secrets.NEXUS_PASSWORD }}
+          maven-settings-path: ".ci.settings.xml"

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -18,6 +18,11 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
+      - name: Create Maven Wrapper properties
+        run: |
+          mkdir -p .mvn/wrapper
+          echo "distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip" > .mvn/wrapper/maven-wrapper.properties
+          echo "wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.2/maven-wrapper-3.3.2.jar" >> .mvn/wrapper/maven-wrapper.properties
       - uses: Alfresco/alfresco-build-tools/.github/actions/maven-dependency-scan@v17.6.1
         with:
           java-version: '21'

--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -1,4 +1,4 @@
-name: Veracode and Nightly Tests run
+name: Nightly Tests run
 
 on:
   schedule:

--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -8,26 +8,6 @@ env:
   MAVEN_CLI_OPTS: "-B -e -fae -V -DinstallAtEnd=true -DfailIfNoTests=false -U -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Pdistribution "
 
 jobs:
-  veracode_sca:
-    name: "Veracode - Source Clear Scan (SCA)"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: Alfresco/alfresco-build-tools/.github/actions/free-hosted-runner-disk-space@v17.6.1
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-java-build@v17.6.1
-      - uses: Alfresco/alfresco-build-tools/.github/actions/veracode@v17.6.1
-        env:
-          MAVEN_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-          MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}
-        with:
-          srcclr-api-token: ${{ secrets.SRCCLR_API_TOKEN }}
-      - name: "Notify on failure"
-        if: failure()
-        uses: Alfresco/alfresco-build-tools/.github/actions/send-teams-notification@v17.6.1
-        with:
-          webhook-url: ${{ secrets.MS_TEAMS_WEBHOOK_URL }}
-          message: "Veracode SCA scan failed"
-
   nightly_tests:
     name: "Run nightly tests"
     runs-on: ubuntu-latest

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -153,7 +153,7 @@
         "filename": "common-test/src/main/java/org/alfresco/hxi_connector/common/test/docker/util/DockerContainers.java",
         "hashed_secret": "a4a747bd4ba5e3a5049cad116881867c71fb625b",
         "is_verified": false,
-        "line_number": 78,
+        "line_number": 79,
         "is_secret": false
       }
     ],
@@ -306,5 +306,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-10T15:39:50Z"
+  "generated_at": "2026-06-08T13:37:30Z"
 }

--- a/common-test/src/main/java/org/alfresco/hxi_connector/common/test/docker/util/DockerContainers.java
+++ b/common-test/src/main/java/org/alfresco/hxi_connector/common/test/docker/util/DockerContainers.java
@@ -43,6 +43,7 @@ import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
 import org.wiremock.integrations.testcontainers.WireMockContainer;
 
 import org.alfresco.hxi_connector.common.test.docker.repository.AlfrescoRepositoryContainer;
@@ -195,9 +196,19 @@ public class DockerContainers
 
     public static GenericContainer<?> createActiveMqContainer()
     {
+        // Wait on the broker's own "started" log line. The default HostPortWaitStrategy
+        // races the openwire port bind on CI and times out before the broker is reachable.
+        // Also overlay a jetty.xml that adds 0.0.0.0/0 to the web-console InetAccessHandler
+        // allow-list. The shipped 5.19 file allows only loopback, so on Linux CI the Jolokia
+        // probe gets HTTP 403 from the Docker bridge gateway IP (macOS Docker Desktop happens
+        // to present host traffic as loopback, hence the local discrepancy).
         return new GenericContainer<>(DockerImageName.parse(ACTIVE_MQ_IMAGE).withTag(ACTIVE_MQ_TAG))
                 .withEnv("JAVA_OPTS", "-Xms512m -Xmx1g")
                 .withExposedPorts(61616, 8161, 5672, 61613)
+                .withCopyFileToContainer(
+                        MountableFile.forClasspathResource("docker/activemq/jetty.xml"),
+                        "/opt/activemq/conf/jetty.xml")
+                .waitingFor(Wait.forLogMessage(".*Apache ActiveMQ.*started.*\\n", 1))
                 .withStartupTimeout(Duration.ofMinutes(2));
     }
 

--- a/common-test/src/main/resources/docker/activemq/jetty.xml
+++ b/common-test/src/main/resources/docker/activemq/jetty.xml
@@ -1,0 +1,346 @@
+<?xml version="1.0"?>
+<!--
+        Licensed to the Apache Software Foundation (ASF) under one or more contributor
+        license agreements. See the NOTICE file distributed with this work for additional
+        information regarding copyright ownership. The ASF licenses this file to You under
+        the Apache License, Version 2.0 (the "License"); you may not use this file except in
+        compliance with the License. You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or
+        agreed to in writing, software distributed under the License is distributed on an
+        "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+        implied. See the License for the specific language governing permissions and
+        limitations under the License.
+    -->
+<!--
+        An embedded servlet engine for serving up the Admin consoles, REST and Ajax APIs and
+        some demos Include this file in your configuration to enable ActiveMQ web components
+        e.g. <import resource="jetty.xml"/>
+    -->
+<!--
+    Test-only copy of the alfresco-activemq image's jetty.xml. Mounted over the
+    shipped file by DockerContainers#createActiveMqContainer so Jolokia/Hawtio
+    are reachable from the host. The image (5.19+) wires an InetAccessHandler
+    that allows only 127.0.0.1 and ::1; from a Testcontainer, requests arrive
+    with the Docker bridge gateway IP and get rejected with HTTP 403 before
+    they reach Jolokia. Below adds 0.0.0.0/0 to the include list (search for
+    'inetAccessIncludeAll'). Tests only — never ship this in production.
+    -->
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+  <bean id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
+    <property name="sendServerVersion" value="false"/>
+    <property name="sendXPoweredBy" value="false"/>
+    <property name="sendDateHeader" value="false"/>
+    <!--
+            When the web console sits behind a reverse proxy or load balancer,
+            uncomment the customizer below so Jetty honors X-Forwarded-* (or
+            RFC 7239 Forwarded) headers when populating request.getRemoteAddr(),
+            request.getScheme(), etc. This is what gets the real client IP into
+            access logs and audit trails.
+
+            WARNING: ForwardedRequestCustomizer trusts these headers from any
+            client. Only enable it when the upstream proxy strips inbound
+            X-Forwarded-* headers, otherwise a remote client can spoof its
+            source IP and apparent scheme.
+
+            Note: this does NOT change InetAccessHandler's filtering — that
+            handler always evaluates the socket peer (the proxy itself) and
+            ignores forwarded headers. In a proxied deployment either keep the
+            allow list scoped to the proxy address and rely on the proxy for
+            client-IP filtering, or remove InetAccessHandler entirely.
+        -->
+    <!--
+        <property name="customizers">
+            <list>
+                <bean class="org.eclipse.jetty.server.ForwardedRequestCustomizer"/>
+            </list>
+        </property>
+        -->
+  </bean>
+  <bean id="securityLoginService" class="org.eclipse.jetty.security.HashLoginService">
+    <property name="name" value="ActiveMQRealm"/>
+    <property name="config" value="${activemq.conf}/jetty-realm.properties"/>
+  </bean>
+  <bean id="securityConstraint" class="org.eclipse.jetty.util.security.Constraint">
+    <property name="name" value="BASIC"/>
+    <property name="roles" value="user,admin"/>
+    <!-- set authenticate=false to disable login -->
+    <property name="authenticate" value="true"/>
+  </bean>
+  <bean id="adminSecurityConstraint" class="org.eclipse.jetty.util.security.Constraint">
+    <property name="name" value="BASIC"/>
+    <property name="roles" value="admin"/>
+    <!-- set authenticate=false to disable login -->
+    <property name="authenticate" value="true"/>
+  </bean>
+  <bean id="securityConstraintMapping" class="org.eclipse.jetty.security.ConstraintMapping">
+    <property name="constraint" ref="securityConstraint"/>
+    <property name="pathSpec" value="/,/api/*,*.jsp,*.html,*.js,*.css,*.png,*.gif,*.ico"/>
+  </bean>
+  <bean id="adminSecurityConstraintMapping" class="org.eclipse.jetty.security.ConstraintMapping">
+    <property name="constraint" ref="adminSecurityConstraint"/>
+    <property name="pathSpec" value="*.action"/>
+  </bean>
+  <bean id="jolokiaSecurityConstraintMapping" class="org.eclipse.jetty.security.ConstraintMapping">
+    <property name="constraint" ref="adminSecurityConstraint"/>
+    <property name="pathSpec" value="/api/jolokia/*"/>
+  </bean>
+  <bean id="rewriteHandler" class="org.eclipse.jetty.rewrite.handler.RewriteHandler">
+    <property name="rules">
+      <list>
+        <bean id="header" class="org.eclipse.jetty.rewrite.handler.HeaderPatternRule">
+          <property name="pattern" value="*"/>
+          <property name="name" value="X-FRAME-OPTIONS"/>
+          <property name="value" value="SAMEORIGIN"/>
+        </bean>
+        <bean id="header" class="org.eclipse.jetty.rewrite.handler.HeaderPatternRule">
+          <property name="pattern" value="*"/>
+          <property name="name" value="X-XSS-Protection"/>
+          <property name="value" value="1; mode=block"/>
+        </bean>
+        <bean id="header" class="org.eclipse.jetty.rewrite.handler.HeaderPatternRule">
+          <property name="pattern" value="*"/>
+          <property name="name" value="X-Content-Type-Options"/>
+          <property name="value" value="nosniff"/>
+        </bean>
+        <bean id="header" class="org.eclipse.jetty.rewrite.handler.HeaderPatternRule">
+          <property name="pattern" value="*"/>
+          <property name="name" value="Cache-Control"/>
+          <property name="value" value="no-store"/>
+        </bean>
+        <bean id="header" class="org.eclipse.jetty.rewrite.handler.HeaderPatternRule">
+          <property name="pattern" value="*"/>
+          <property name="name" value="Content-Security-Policy"/>
+          <property name="value" value="upgrade-insecure-requests; style-src-elem 'self'; style-src 'self'; img-src 'self'; script-src-elem 'self'; default-src 'none'; object-src 'none'; frame-ancestors 'none'; base-uri 'none';"/>
+        </bean>
+        <bean id="header" class="org.eclipse.jetty.rewrite.handler.HeaderPatternRule">
+          <property name="pattern" value="*"/>
+          <property name="name" value="Referrer-Policy"/>
+          <property name="value" value="no-referrer"/>
+        </bean>
+        <bean id="header" class="org.eclipse.jetty.rewrite.handler.HeaderPatternRule">
+          <property name="pattern" value="*"/>
+          <property name="name" value="Permissions-Policy"/>
+          <property name="value" value="accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()"/>
+        </bean>
+        <bean id="header" class="org.eclipse.jetty.rewrite.handler.HeaderPatternRule">
+          <property name="pattern" value="*"/>
+          <property name="name" value="Cross-Origin-Opener-Policy"/>
+          <property name="value" value="same-origin"/>
+        </bean>
+        <bean id="header" class="org.eclipse.jetty.rewrite.handler.HeaderPatternRule">
+          <property name="pattern" value="*"/>
+          <property name="name" value="Cross-Origin-Resource-Policy"/>
+          <property name="value" value="same-origin"/>
+        </bean>
+        <!-- More relaxed rules to allow browsers to properly render XML -->
+        <bean id="header" class="org.eclipse.jetty.rewrite.handler.HeaderPatternRule">
+          <property name="pattern" value="/admin/xml/*"/>
+          <property name="name" value="Content-Security-Policy"/>
+          <property name="value" value="upgrade-insecure-requests; style-src-elem 'self' 'unsafe-inline'; style-src 'self'; img-src 'self' data:; script-src-elem 'self'; default-src 'none'; object-src 'none'; frame-ancestors 'none'; base-uri 'none';"/>
+        </bean>
+        <!-- Uncomment when serving the console over HTTPS only -->
+        <!--
+                <bean id="header" class="org.eclipse.jetty.rewrite.handler.HeaderPatternRule">
+                    <property name="pattern" value="*"/>
+                    <property name="name" value="Strict-Transport-Security"/>
+                    <property name="value" value="max-age=31536000; includeSubDomains"/>
+                </bean>
+                -->
+      </list>
+    </property>
+  </bean>
+  <bean id="secHandlerCollection" class="org.eclipse.jetty.server.handler.HandlerCollection">
+    <property name="handlers">
+      <list>
+        <ref bean="rewriteHandler"/>
+        <bean class="org.eclipse.jetty.webapp.WebAppContext">
+          <property name="contextPath" value="/admin"/>
+          <property name="resourceBase" value="${activemq.home}/webapps/admin"/>
+          <property name="logUrlOnStart" value="true"/>
+        </bean>
+        <bean class="org.eclipse.jetty.webapp.WebAppContext">
+          <property name="contextPath" value="/api"/>
+          <property name="resourceBase" value="${activemq.home}/webapps/api"/>
+          <property name="logUrlOnStart" value="true"/>
+        </bean>
+        <bean class="org.eclipse.jetty.server.handler.ResourceHandler">
+          <property name="directoriesListed" value="false"/>
+          <property name="welcomeFiles">
+            <list>
+              <value>index.html</value>
+            </list>
+          </property>
+          <property name="resourceBase" value="${activemq.home}/webapps/"/>
+        </bean>
+        <bean id="defaultHandler" class="org.eclipse.jetty.server.handler.DefaultHandler">
+          <property name="serveIcon" value="false"/>
+        </bean>
+      </list>
+    </property>
+  </bean>
+  <bean id="securityHandler" class="org.eclipse.jetty.security.ConstraintSecurityHandler">
+    <property name="loginService" ref="securityLoginService"/>
+    <property name="authenticator">
+      <bean class="org.eclipse.jetty.security.authentication.BasicAuthenticator"/>
+    </property>
+    <property name="constraintMappings">
+      <list>
+        <ref bean="adminSecurityConstraintMapping"/>
+        <ref bean="jolokiaSecurityConstraintMapping"/>
+        <ref bean="securityConstraintMapping"/>
+      </list>
+    </property>
+    <property name="handler" ref="secHandlerCollection"/>
+  </bean>
+  <bean id="contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection">
+    </bean>
+  <bean id="jettyPort" class="org.apache.activemq.web.WebConsolePort" init-method="start">
+    <!-- the default port number for the web console -->
+    <property name="host" value="0.0.0.0"/>
+    <property name="port" value="8161"/>
+  </bean>
+  <bean id="handlers" class="org.eclipse.jetty.server.handler.HandlerCollection">
+    <property name="handlers">
+      <list>
+        <ref bean="contexts"/>
+        <ref bean="securityHandler"/>
+      </list>
+    </property>
+  </bean>
+  <!--
+        IP-based access control for the web console.
+        Patterns accept: exact IP (192.168.1.1), CIDR (10.0.0.0/8),
+        range (10.0.0.0-10.255.255.255), or qualified with path/connector
+        using '|' (e.g. 192.168.1.0/24|/api).
+        Exclude rules take precedence over include rules.
+        With the default host binding of 127.0.0.1, only localhost is reachable;
+        if the bind address is broadened (e.g. 0.0.0.0), add explicit include
+        entries below for the networks that should reach the console.
+    -->
+  <bean id="inetAccessHandler" class="org.eclipse.jetty.server.handler.InetAccessHandler">
+    <property name="handler" ref="handlers"/>
+  </bean>
+  <!-- Allowed clients (include rules) -->
+  <bean id="inetAccessIncludeLoopbackV4" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+    <property name="targetObject" ref="inetAccessHandler"/>
+    <property name="targetMethod" value="include"/>
+    <property name="arguments">
+      <list>
+        <value>127.0.0.1</value>
+      </list>
+    </property>
+  </bean>
+  <bean id="inetAccessIncludeLoopbackV6" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean" depends-on="inetAccessIncludeLoopbackV4">
+    <property name="targetObject" ref="inetAccessHandler"/>
+    <property name="targetMethod" value="include"/>
+    <property name="arguments">
+      <list>
+        <value>::1</value>
+      </list>
+    </property>
+  </bean>
+  <!--
+        Example: allow standard private network ranges. Copy a block and
+        chain depends-on to enforce ordering on container startup.
+
+    <bean id="inetAccessIncludeRfc1918Class10" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean"
+          depends-on="inetAccessIncludeLoopbackV6">
+        <property name="targetObject" ref="inetAccessHandler"/>
+        <property name="targetMethod" value="include"/>
+        <property name="arguments">
+            <list><value>10.0.0.0/8</value></list>
+        </property>
+    </bean>
+    <bean id="inetAccessIncludeRfc1918Class172" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean"
+          depends-on="inetAccessIncludeRfc1918Class10">
+        <property name="targetObject" ref="inetAccessHandler"/>
+        <property name="targetMethod" value="include"/>
+        <property name="arguments">
+            <list><value>172.16.0.0/12</value></list>
+        </property>
+    </bean>
+    <bean id="inetAccessIncludeRfc1918Class192" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean"
+          depends-on="inetAccessIncludeRfc1918Class172">
+        <property name="targetObject" ref="inetAccessHandler"/>
+        <property name="targetMethod" value="include"/>
+        <property name="arguments">
+            <list><value>192.168.0.0/16</value></list>
+        </property>
+    </bean>
+    -->
+  <!--
+        Denied clients (exclude rules). Exclude rules take precedence over
+        include rules. Empty by default; add entries below to block specific
+        addresses or networks.
+
+    <bean id="inetAccessExcludeExample" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean"
+          depends-on="inetAccessIncludeLoopbackV6">
+        <property name="targetObject" ref="inetAccessHandler"/>
+        <property name="targetMethod" value="exclude"/>
+        <property name="arguments">
+            <list><value>1.2.3.4</value></list>
+        </property>
+    </bean>
+    -->
+    <bean id="inetAccessIncludeAll" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean" depends-on="inetAccessIncludeLoopbackV6">
+    <property name="targetObject" ref="inetAccessHandler"/>
+    <property name="targetMethod" value="include"/>
+    <property name="arguments">
+      <list>
+        <value>0.0.0.0/0</value>
+      </list>
+    </property>
+  </bean>
+  <bean id="Server" depends-on="jettyPort" class="org.eclipse.jetty.server.Server" destroy-method="stop">
+    <property name="handler" ref="inetAccessHandler"/>
+  </bean>
+  <bean id="invokeConnectors" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+    <property name="targetObject" ref="Server"/>
+    <property name="targetMethod" value="setConnectors"/>
+    <property name="arguments">
+      <list>
+        <bean id="Connector" class="org.eclipse.jetty.server.ServerConnector">
+          <constructor-arg ref="Server"/>
+          <constructor-arg>
+            <list>
+              <bean id="httpConnectionFactory" class="org.eclipse.jetty.server.HttpConnectionFactory">
+                <constructor-arg ref="httpConfig"/>
+              </bean>
+            </list>
+          </constructor-arg>
+          <!-- see the jettyPort bean -->
+          <property name="host" value="#{systemProperties['jetty.host']}"/>
+          <property name="port" value="#{systemProperties['jetty.port']}"/>
+        </bean>
+        <!--
+                    Enable this connector if you wish to use https with web console
+                -->
+        <!-- bean id="SecureConnector" class="org.eclipse.jetty.server.ServerConnector">
+					<constructor-arg ref="Server" />
+					<constructor-arg>
+						<bean id="handlers" class="org.eclipse.jetty.util.ssl.SslContextFactory">
+
+							<property name="keyStorePath" value="${activemq.conf}/broker.ks" />
+							<property name="keyStorePassword" value="password" />
+						</bean>
+					</constructor-arg>
+					<property name="port" value="8162" />
+				</bean -->
+      </list>
+    </property>
+  </bean>
+  <bean id="configureJetty" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+    <property name="staticMethod" value="org.apache.activemq.web.config.JspConfigurer.configureJetty"/>
+    <property name="arguments">
+      <list>
+        <ref bean="Server"/>
+        <ref bean="secHandlerCollection"/>
+      </list>
+    </property>
+  </bean>
+  <bean id="invokeStart" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean" depends-on="broker, configureJetty, invokeConnectors, inetAccessIncludeAll">
+    <property name="targetObject" ref="Server"/>
+    <property name="targetMethod" value="start"/>
+  </bean>
+</beans>

--- a/common/src/main/resources/logback-spring.xml
+++ b/common/src/main/resources/logback-spring.xml
@@ -8,10 +8,6 @@
     every module without requiring callers to remember to sanitize at each log site.
 
     See: https://logback.qos.ch/manual/layouts.html#replace
-
-    NOTE - Veracode SAST does not see runtime Logback configuration and will keep flagging the
-    raw log statements as CWE-117. Those findings should be marked as "Mitigated by Design" in
-    the Veracode UI, referencing this file.
 -->
 <configuration>
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>

--- a/srcclr.yml
+++ b/srcclr.yml
@@ -1,5 +1,0 @@
-# To avoid the provided dependencies we set the scope to runtime. See: https://docs.veracode.com/r/c_sc_scan_directives
-# runtime: to restrict the scan to compile and runtime dependencies.
-scope: runtime
-# using a custom maven command to skip test modules
-custom_maven_command: clean install -Dmaven.test.skip -P !test -pl "!common-test,!e2e-test"


### PR DESCRIPTION
This pull request introduces several updates to CI/CD workflows and test utilities.  The most significant changes are the removal of Veracode security scans from the CI and nightly workflows, the addition of a dedicated dependency graph workflow, and improvements to the ActiveMQ test container setup. 

**CI/CD workflow changes:**

* Removed Veracode SAST and SCA security scan jobs from both the main CI workflow
* Added a new `dependency-graph.yml` workflow to regularly scan and upload the Maven dependency graph, supporting better dependency tracking and visibility. 
* Updated `.github/dependabot.yml` to use a new internal Maven registry and grouped GitHub Actions updates for improved automation and clarity.

**Test container improvements:**

* Fixed CI-only Jolokia probe failure caused by ActiveMQ 5.19's stricter `InetAccessHandler` - the shipped image now restricts web console access to loopback only; on Linux CI the Docker bridge gateway IP is not loopback, causing HTTP 403 on the Jolokia health check. A custom jetty.xml is mounted into the test container at startup to add 0.0.0.0/0 to the allow-list. This file is scoped to common-test and never shipped to production.
